### PR TITLE
feat: glob matching for `to_tuple`

### DIFF
--- a/webdataset/iterators.py
+++ b/webdataset/iterators.py
@@ -17,6 +17,7 @@ __all__ = "WebDataset tariterator default_handlers imagehandler".split()
 
 import random
 import sys
+import fnmatch
 from functools import reduce
 
 import numpy as np
@@ -71,8 +72,9 @@ def getfirst(a, keys, default=None, missing_is_error=True):
         assert " " not in keys
         keys = keys.split(";")
     for k in keys:
-        if k in a:
-            return a[k]
+        for file in a:
+            if fnmatch.fnmatch(file, k):
+                return a[file]
     if missing_is_error:
         raise ValueError(f"didn't find {keys} in {list(a.keys())}")
     return default


### PR DESCRIPTION
Allows glob-like file matching on the `to_tuple` function, eg:

```
wd.Dataset(file_path).decode().to_tuple("sample*", "sample*")
```

If the user wants to support variable file extension of same naming convention.