### PR TITLE
Install wheel and twine to re-enable pypi build

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -13,6 +13,9 @@ flake8
 pydocstyle
 bandit
 
+twine
+wheel
+
 #Pillow
 #numpy
 #scipy
@@ -20,5 +23,3 @@ bandit
 #mkdocs
 #nbconvert
 #pynvim
-#twine
-#wheel


### PR DESCRIPTION
Wheels have not been building and uploading to PyPi since 1.62 since the `wheel` and `twine` requirements were disabled.

This un-comments them from the `requirements.txt`.