### PR TITLE
fix: remove debug comment

### DIFF
--- a/webdataset/dataset.py
+++ b/webdataset/dataset.py
@@ -56,7 +56,6 @@ class Composable:
         """
         assert callable(f)
         assert "source" not in kw
-        # print("Processor", args, kw)
         return Processor(self, f, *args, **kw)
 
     def compose(self, constructor, *args, **kw):


### PR DESCRIPTION
Looks like a debug print statement commented out was left behind on accident.