### PR TITLE
Add missing_is_error to Processor.to_tuple port

### DIFF
--- a/webdataset/composable.py
+++ b/webdataset/composable.py
@@ -181,7 +181,7 @@ class Shorthands:
         """
         return self.then(iterators.select, predicate, _kwa=kw)
 
-    def to_tuple(self, *args, handler=reraise_exception):
+    def to_tuple(self, *args, handler=reraise_exception, **kw):
         """Convert a dictionary-based sample to a tuple.
 
         Field names to be extracted can be specified as a Python list
@@ -191,8 +191,10 @@ class Shorthands:
 
         :param args: field names
         :param handler: exception handler
+        :param missing_is_error: whether to ignore fields missing from samples and replace them by None
+        :param none_is_error: whether reading a None triggers an exception, defaults to missing_is_error
         """
-        return self.then(iterators.to_tuple, *args, handler=handler)
+        return self.then(iterators.to_tuple, *args, handler=handler, **kw)
 
     def map_tuple(self, *args, handler=reraise_exception):
         """Map a tuple.


### PR DESCRIPTION
Add documentation to `to_tuple` about what `missing_is_error` and `none_is_error` are doing, and allows their usage in the chained version of `to_tuple` like so:

```python3
dataset = (
    wds.WebDataset("truc_00000.tar")
    .decode(wds.handle_extension("mask.png", png_decoder_1bpp))
    .to_tuple("1.mask.png", "2.mask.png", "3.mask.png", "cls", missing_is_error=False)
)

for stuff in dataset:
    print("#")
    for stuf in stuff:
        print(type(stuf))
```

Prints:
```python3
#
<class 'imageio.core.util.Array'>
<class 'imageio.core.util.Array'>
<class 'NoneType'>
<class 'NoneType'>
<class 'NoneType'>
<class 'int'>
#
<class 'imageio.core.util.Array'>
<class 'imageio.core.util.Array'>
<class 'imageio.core.util.Array'>
<class 'NoneType'>
<class 'NoneType'>
<class 'int'>
#
<class 'imageio.core.util.Array'>
<class 'NoneType'>
<class 'NoneType'>
<class 'NoneType'>
<class 'NoneType'>
<class 'int'>
```

This avoids doing that:
```python3
dataset = (
    wds.WebDataset("truc_00000.tar")
    .decode(wds.handle_extension("mask.png", png_decoder_1bpp))
)
dataset = wds.iterators.to_tuple(dataset, "1.mask.png", "2.mask.png", "3.mask.png", "cls", missing_is_error=False)
```