### PR TITLE
Added custom error message for shard pattern name

### DIFF
--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -385,7 +385,13 @@ class ShardWriter:
     def next_stream(self):
         """Close the current stream and move to the next."""
         self.finish()
-        self.fname = self.pattern % self.shard
+
+        try:
+            self.fname = self.pattern % self.shard
+        except TypeError:
+            raise TypeError("The input pattern \"{}\" is malformed. It was expected to "
+                            "the pattern be like \"dataset%06d.tar\"".format(self.pattern))
+
         if self.verbose:
             print(
                 "# writing",


### PR DESCRIPTION
In the current code if the user tries to create a `ShardWriter` without passing the shard number pattern in the `pattern` parameter, the user will get the following awful error message:
```py
import webdataset as wds
wds.ShardWriter("test.tar")
```
`TypeError: not all arguments converted during string formatting`

The default message given by Python is not informative enough. This patch only adds an error message when this error occurs.

With the provided modifications, the user will see this error message:
`TypeError: The input pattern "test.tar" is malformed. It was expected to the pattern be like "dataset%06d.tar"` 