### PR TITLE
Add ability to re-create bit-exact Webdatasets

### DIFF
--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -290,7 +290,7 @@ class TarWriter:
         self.encoder = make_encoder(encoder)
         self.keep_meta = keep_meta
         self.stream = fileobj
-        self.tarstream = tarfile.open(fileobj=fileobj, mode=tarmode)
+        self.tarstream = tarfile.open(fileobj=fileobj, mode=tarmode, format=tarfile.PAX_FORMAT)
 
         self.user = user
         self.group = group

--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -312,10 +312,11 @@ class TarWriter:
             self.own_fileobj.close()
             self.own_fileobj = None
 
-    def write(self, obj):
+    def write(self, obj, mtime=None):
         """Write a dictionary to the tar file.
 
         :param obj: dictionary of objects to be stored
+        :param mtime: optional modification time for object in unix epochs
         :returns: size of the entry
 
         """
@@ -337,10 +338,11 @@ class TarWriter:
             v = obj[k]
             if isinstance(v, str):
                 v = v.encode("utf-8")
-            now = time.time()
+            if mtime is None:
+                mtime = time.time()
             ti = tarfile.TarInfo(key + "." + k)
             ti.size = len(v)
-            ti.mtime = now
+            ti.mtime = mtime
             ti.mode = self.mode
             ti.uname = self.user
             ti.gname = self.group

--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -312,11 +312,10 @@ class TarWriter:
             self.own_fileobj.close()
             self.own_fileobj = None
 
-    def write(self, obj, mtime=None):
+    def write(self, obj):
         """Write a dictionary to the tar file.
 
         :param obj: dictionary of objects to be stored
-        :param mtime: optional modification time for object in unix epochs
         :returns: size of the entry
 
         """
@@ -338,11 +337,9 @@ class TarWriter:
             v = obj[k]
             if isinstance(v, str):
                 v = v.encode("utf-8")
-            if mtime is None:
-                mtime = time.time()
             ti = tarfile.TarInfo(key + "." + k)
             ti.size = len(v)
-            ti.mtime = mtime
+            ti.mtime = 0.0
             ti.mode = self.mode
             ti.uname = self.user
             ti.gname = self.group
@@ -406,15 +403,14 @@ class ShardWriter:
         self.count = 0
         self.size = 0
 
-    def write(self, obj, mtime=None):
+    def write(self, obj):
         """Write a sample.
 
         :param obj: sample to be written
-        :param mtime: optional modification time for object in unix epochs
         """
         if self.tarstream is None or self.count >= self.maxcount or self.size >= self.maxsize:
             self.next_stream()
-        size = self.tarstream.write(obj, mtime=mtime)
+        size = self.tarstream.write(obj)
         self.count += 1
         self.total += 1
         self.size += size

--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -406,14 +406,15 @@ class ShardWriter:
         self.count = 0
         self.size = 0
 
-    def write(self, obj):
+    def write(self, obj, mtime=None):
         """Write a sample.
 
         :param obj: sample to be written
+        :param mtime: optional modification time for object in unix epochs
         """
         if self.tarstream is None or self.count >= self.maxcount or self.size >= self.maxsize:
             self.next_stream()
-        size = self.tarstream.write(obj)
+        size = self.tarstream.write(obj, mtime=mtime)
         self.count += 1
         self.total += 1
         self.size += size


### PR DESCRIPTION
Currently it is impossible to re-create bit-exact Webdatasets, as each file in the Tar archive has a different mtime. This has slightly annoying implications for file caching and versioning, as you have to deal with changed-but-not-really-changed files all the time.

My first question is: Is this on purpose? Does mtime encode any valuable information for the user?

If no, why not set it to a fixed value, e.g. `1970-01-01`?

If yes, why not make it overridable by the user, e.g. by a `mtime` kwarg?

Currently, this PR does the latter: It introduces a parameter that allows me to override this value.

## To reproduce

```python
import webdataset as wds

for f in ["test1.tar", "test2.tar"]:
    with wds.TarWriter(f) as sink:
        sink.write(
            {
                "__key__": "sample0000",
                "input.txt": "1",
                "output.txt": "2",
            },
        )
```

```sh
$ md5sum *.tar
0f90a5b6ca6f0e423685e23cad872d36  test1.tar                                                                                                                                                                                                                                     
49e91eaa9c54125897b2286af2757c0e  test2.tar
$ tar tvf test1.tar 
-r--r--r-- bigdata/bigdata   1 2021-11-28 15:16 sample0000.input.txt
-r--r--r-- bigdata/bigdata   1 2021-11-28 15:16 sample0000.output.txt
$ tar tvf test1.tar 
-r--r--r-- bigdata/bigdata   1 2021-11-28 15:16 sample0000.input.txt     # the dates are off by microseconds
-r--r--r-- bigdata/bigdata   1 2021-11-28 15:16 sample0000.output.txt    # the dates are off by microseconds
```

## Behaviour after this PR

With this PR it is possible to override the `mtime` parameter of `TarWriter.write(...)`, and to set it to arbitrary fixed values:

```python
import webdataset as wds

for f in ["test1.tar", "test2.tar"]:
    with wds.TarWriter(f) as sink:
        sink.write(
            {
                "__key__": "sample0000",
                "input.txt": "1",
                "output.txt": "2",
            },
            mtime=0.0
        )
```

which creates bit-exact copies of the output file:

```sh
$ md5sum *.tar
b1de8150b28126256f05943741b2b5ab  test1.tar
b1de8150b28126256f05943741b2b5ab  test2.tar
$ tar tvf test1.tar 
-r--r--r-- bigdata/bigdata   1 1970-01-01 01:00 sample0000.input.txt
-r--r--r-- bigdata/bigdata   1 1970-01-01 01:00 sample0000.output.txt
$ tar tvf test2.tar 
-r--r--r-- bigdata/bigdata   1 1970-01-01 01:00 sample0000.input.txt
-r--r--r-- bigdata/bigdata   1 1970-01-01 01:00 sample0000.output.txt
```