### PR TITLE
do not make map function pollute result data

### DIFF
--- a/webdataset/iterators.py
+++ b/webdataset/iterators.py
@@ -240,7 +240,8 @@ def map(data, f, handler=reraise_exception):
             else:
                 break
         if isinstance(sample, dict) and isinstance(result, dict):
-            result["__key__"] = sample.get("__key__")
+            if "__key__" in sample:
+                result["__key__"] = sample.get("__key__")
         yield result
 
 


### PR DESCRIPTION
the user may not want "`__key__`" data in the sample, they can pop it out in the `f` function