### PR TITLE
Fix typo in __init__.py and add version information

### DIFF
--- a/webdataset/__init__.py
+++ b/webdataset/__init__.py
@@ -7,8 +7,6 @@
 
 """Exported globals for webdataset library."""
 
-import pkg_resources
-
 from . import tenbin
 from .autodecode import (
     Continue,
@@ -76,4 +74,14 @@ from .utils import PipelineStage, repeatedly
 from .writer import ShardWriter, TarWriter, numpy_dumps, torch_dumps
 from .mix import RandomMix, RoundRobin
 
-__version__ = pkg_resources.require("webdataset")[0].version
+try:
+    import pkg_resources
+    __version__ = pkg_resources.require("webdataset")[0].version
+except (ImportError, ModuleNotFoundError):
+    import warnings
+    warnings.warn(
+        "Could not infer version information of webdataset package",
+        RuntimeWarning
+    )
+    __version__ = None
+

--- a/webdataset/__init__.py
+++ b/webdataset/__init__.py
@@ -7,6 +7,8 @@
 
 """Exported globals for webdataset library."""
 
+import pkg_resources
+
 from . import tenbin
 from .autodecode import (
     Continue,
@@ -74,4 +76,4 @@ from .utils import PipelineStage, repeatedly
 from .writer import ShardWriter, TarWriter, numpy_dumps, torch_dumps
 from .mix import RandomMix, RoundRobin
 
-__vesion__ = ""
+__version__ = pkg_resources.require("webdataset")[0].version


### PR DESCRIPTION
The package currently has a typo in `webdataset/__init__.py`. Also, it is not possible to query the package version using `webdataset.__version__`.

The PR adds a proposal to retrieve the version when loading the package (via `pkg_resources`). An alternative proposal would be to specify the version in a `webdataset.version` module, and import this in `setup.py`. This would slightly change the workflow for package maintainers when bumping versions, hence I opted for the way via `pkg_resources` (but happy to adapt to your preferences).

To test:

``` bash
$ pip install .
$ python -c 'import webdataset; print(webdataset.__version__)'
0.2.12
```