### PR TITLE
Pass handler to tar_file_iterator

### DIFF
--- a/webdataset/tariterators.py
+++ b/webdataset/tariterators.py
@@ -128,7 +128,7 @@ def tar_file_expander(data, handler=reraise_exception):
         try:
             assert isinstance(source, dict)
             assert "stream" in source
-            for sample in tar_file_iterator(source["stream"]):
+            for sample in tar_file_iterator(source["stream"], handler=handler):
                 assert (
                     isinstance(sample, dict) and "data" in sample and "fname" in sample
                 )


### PR DESCRIPTION
The exception handler is currently away from the `tar_file_iterator`. I am not sure that it is intentional or just a typo. 

I feel that it is a typo since the handler is also used to handle the exceptions caused by a sample (instead of a tar file) in group_by_keys. Thus I proposed this one-line change to resolve this issue.