### PR TITLE
utf-8 decode only triggers on double-underscore, added error msgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ docs/webdataset
 dist
 webdataset.egg-info
 docsrc/*.md
+openimages.py
+rust-test.ipynb
+test.cbors
+test.py
+notebooks/openimages.py
+notebooks/wordtrain.ipynb
+webdataset/tests/test_pipeline.log

--- a/webdataset/autodecode.py
+++ b/webdataset/autodecode.py
@@ -441,9 +441,12 @@ class Decoder:
         result = {}
         assert isinstance(sample, dict), sample
         for k, v in list(sample.items()):
-            if k[0] == "_":
+            if k[0:2] == "__":
                 if isinstance(v, bytes):
-                    v = v.decode("utf-8")
+                    try:
+                        v = v.decode("utf-8")
+                    except:
+                        print(f"Can't decode v of k = {k} as utf-8: v = {v}")
                 result[k] = v
                 continue
             if self.only is not None and k not in self.only:
@@ -456,7 +459,7 @@ class Decoder:
                 else:
                     result[k] = v
             else:
-                assert isinstance(v, bytes)
+                assert isinstance(v, bytes), f"k,v = {k}, {v}"
                 result[k] = self.decode1(k, v)
         return result
 


### PR DESCRIPTION
[The precedence of forcing anything with a leading underscore to be decoded as UTF-8](https://github.com/webdataset/webdataset/blob/686438249b13ba304c85d00b472b25438973ce1e/webdataset/autodecode.py#L444), as described in [this issue](https://github.com/webdataset/webdataset/issues/220), causes it to ignore extension-based processing, e.g. for keys that read like "_stuff.flac".  

It seems the original intent of this underscore-processing was to be used for things with *double underscores*, such as `__key__`, etc.  So this PR simply includes a change so that the extension-ignoring UTF-8 decoding only happens for double-underscores.

I also added a couple error messages, e.g. an explicit statement to be printed when asserts fail. 