### PR TITLE
Use `gopen` instead of `open` for the sharded tar writer.

### DIFF
--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -409,7 +409,7 @@ class ShardWriter:
                 self.total,
             )
         self.shard += 1
-        stream = open(self.fname, "wb")
+        stream = gopen.gopen(self.fname, "wb")
         self.tarstream = TarWriter(stream, **self.kw)
         self.count = 0
         self.size = 0

--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -25,6 +25,10 @@ def imageencoder(image: Any, format: str = "PNG"):  # skipcq: PYL-W0622
     """
     import PIL
 
+    # Fix `AttributeError: module 'PIL' has no attribute 'Image'` triggered otherwise
+    # by the next line.
+    from PIL import Image
+
     assert isinstance(image, (PIL.Image.Image, np.ndarray)), type(image)
 
     if isinstance(image, np.ndarray):


### PR DESCRIPTION
gopen implements unified access to the different file systems. It is used for the unsharded tarwriter, however, not for the sharded one. This PR fixes this and makes it consistent.