### PR TITLE
For ShardWriter, add verbose as constructor param

### DIFF
--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -377,6 +377,7 @@ class ShardWriter:
         maxsize: float = 3e9,
         post: Optional[Callable] = None,
         start_shard: int = 0,
+        verbose: int = 1,
         **kw,
     ):
         """Create a ShardWriter.
@@ -386,7 +387,7 @@ class ShardWriter:
         :param maxsize: maximum size of each shard (Default value = 3e9)
         :param kw: other options passed to TarWriter
         """
-        self.verbose = 1
+        self.verbose = verbose
         self.kw = kw
         self.maxcount = maxcount
         self.maxsize = maxsize


### PR DESCRIPTION
## Problem
Currently, verbose cannot be entirely overwritten. Consider the following:
```python
with wds.ShardWriter(pattern) as sink:
    sink.verbose = False # or sink.verbose = 0
    for index, (file, label) in enumerate(data.items()):
        sink.write({
            ...
````
Because of [`self.next_stream()`](https://github.com/webdataset/webdataset/blob/main/webdataset/writer.py#L402) in the constructor, setting verbose after the constructor is not sufficient.

## Solution
This PR lets verbose be set in the constructor. 

## Details
Issue: #133 