### PR TITLE
Close streams once consumed

### DIFF
--- a/webdataset/gopen.py
+++ b/webdataset/gopen.py
@@ -115,6 +115,10 @@ class Pipe:
         """Context handler."""
         self.close()
 
+    def __del__(self):
+        """Close the stream upon delete."""
+        self.close()
+
 
 def set_options(
     obj, timeout=None, ignore_errors=None, ignore_status=None, handler=None

--- a/webdataset/tariterators.py
+++ b/webdataset/tariterators.py
@@ -88,9 +88,9 @@ def url_opener(
         assert "url" in sample
         url = sample["url"]
         try:
-            with gopen.gopen(url, **kw) as stream:
-                sample.update(stream=stream)
-                yield sample
+            stream = gopen.gopen(url, **kw)
+            sample.update(stream=stream)
+            yield sample
         except Exception as exn:
             exn.args = exn.args + (url,)
             if handler(exn):

--- a/webdataset/tariterators.py
+++ b/webdataset/tariterators.py
@@ -88,9 +88,9 @@ def url_opener(
         assert "url" in sample
         url = sample["url"]
         try:
-            stream = gopen.gopen(url, **kw)
-            sample.update(stream=stream)
-            yield sample
+            with gopen.gopen(url, **kw) as stream:
+                sample.update(stream=stream)
+                yield sample
         except Exception as exn:
             exn.args = exn.args + (url,)
             if handler(exn):


### PR DESCRIPTION
Wrap `gopen.gopen` using `with`, which ensures that streams are closed once consumed.