### PR TITLE
Handle hdfs url in pipe_cleaner

### DIFF
--- a/webdataset/cache.py
+++ b/webdataset/cache.py
@@ -62,7 +62,7 @@ def pipe_cleaner(spec):
         spec = spec[5:]
         words = spec.split(" ")
         for word in words:
-            if re.match(r"^(https?|gs|ais|s3):", word):
+            if re.match(r"^(https?|hdfs|gs|ais|s3):", word):
                 return word
     return spec
 


### PR DESCRIPTION
WebDataset already supports loading from piped HDFS source like `pipe:hdfs dfs -cat hdfs://DATA_PATH/{000..064}.tar`, but when I use it with caching via `cached_tarfile_to_samples()`, the default `pipe_cleaner` handles everything except `hdfs`. This behavior causes `pipe_cleaner` to return the full string after "pipe" including all spaces, which can be problematic.

I understand that `url_to_name` can be easily overridden (which I did). But it would be better to support it by default since HDFS is also common.