### PR TITLE
Fix ShardWriter: The open file was not closed

### DIFF
--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -414,8 +414,8 @@ class ShardWriter:
                 self.total,
             )
         self.shard += 1
-        stream = open(self.fname, "wb")
-        self.tarstream = TarWriter(stream, **self.kw)
+        self.own_stream = open(self.fname, "wb")
+        self.tarstream = TarWriter(self.own_stream, **self.kw)
         self.count = 0
         self.size = 0
 
@@ -439,6 +439,7 @@ class ShardWriter:
         """Finish all writing (use close instead)."""
         if self.tarstream is not None:
             self.tarstream.close()
+            self.own_stream.close()
             assert self.fname is not None
             if callable(self.post):
                 self.post(self.fname)


### PR DESCRIPTION
When running unittests or when running python with `python -W default your_file.py`, you will be able to see warnings like these:

    ResourceWarning: unclosed file <_io.BufferedWriter name='.../data-123.tar'>

This was due to the stream opened in ShardWriter which was never closed. Neither TarWriter nor the inner tarfile object close any file objects that are passed in from the outside, so we need to keep a reference in ShardWriter and close it ourselves.
