### PR TITLE
use newer ubuntu image for pypi deployment

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   publish:
     name: build-and-publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - uses: actions/setup-python@v1


### PR DESCRIPTION
Pypi deployments are currently [failing](https://github.com/webdataset/webdataset/actions/runs/5239424937) due to an outdated ubuntu image. Switching this to `ubuntu-latest` should allow this action to find a runner.

Related: actions/runner-images#6002