### PR TITLE
Make pipeline.compose non-destructive

### DIFF
--- a/webdataset/pipeline.py
+++ b/webdataset/pipeline.py
@@ -85,6 +85,7 @@ class DataPipeline(IterableDataset, PipelineStage):
     def compose(self, *args):
         """Append a pipeline stage to a copy of the pipeline and returns the copy."""
         result = copy.copy(self)
+        result.pipeline = copy.copy(result.pipeline)
         for arg in args:
             result.append(arg)
         return result


### PR DESCRIPTION
This is a quick fix for #297 .

It's not very elegant (maybe we could introduce a "copy constructor" in a `copy` method?) but should solve the issue I was seeing.