### PR TITLE
(det)shuffle shardlist before (node/worker) splitting in WebDataset

### DIFF
--- a/webdataset/compat.py
+++ b/webdataset/compat.py
@@ -124,8 +124,6 @@ class WebDataset(DataPipeline, FluidInterface):
             self.append(shardlists.ResampledShards(urls))
         else:
             self.append(shardlists.SimpleShardList(urls))
-            self.append(nodesplitter)
-            self.append(shardlists.split_by_worker)
             if shardshuffle is True:
                 shardshuffle = 100
             if shardshuffle is not None:
@@ -133,6 +131,8 @@ class WebDataset(DataPipeline, FluidInterface):
                     self.append(filters.detshuffle(shardshuffle))
                 else:
                     self.append(filters.shuffle(shardshuffle))
+            self.append(nodesplitter)
+            self.append(shardlists.split_by_worker)
         if cache_dir is None or cache_size == 0:
             self.append(
                 tariterators.tarfile_to_samples(


### PR DESCRIPTION
In distributed training with GPU processes and data loader workers, one common pattern is shuffling the webdataset shards in an identical way across all Python processes, and split based on some consistent rule to have non-overlapping data. This is the strategy [`DistributedSampler`](https://pytorch.org/docs/stable/_modules/torch/utils/data/distributed.html#DistributedSampler) adopts. We can achieve this with the v2 DataPipeline API:

```python
    dataset = wds.DataPipeline(
        wds.SimpleShardList("source-{000000..00007}.tar"),
        wds.detshuffle(),
        wds.split_by_node,
        wds.split_by_worker,
    )
```

```
rank: 0, world_size: 8, {'url': 'source-000006.tar'}
rank: 1, world_size: 8, {'url': 'source-000007.tar'}
rank: 5, world_size: 8, {'url': 'source-000005.tar'}
rank: 2, world_size: 8, {'url': 'source-000003.tar'}
rank: 4, world_size: 8, {'url': 'source-000002.tar'}
rank: 3, world_size: 8, {'url': 'source-000000.tar'}
rank: 6, world_size: 8, {'url': 'source-000001.tar'}
rank: 7, world_size: 8, {'url': 'source-000004.tar'}
```

However, the current `WebDataset` API puts shuffling logic **after** the splitting logic, so shuffling only takes place within each data loader worker on each rank.

```python
    dataset = (
        wds.WebDataset("source-{000000..00007}.tar", shardshuffle=True, detshuffle=True, nodesplitter=wds.split_by_node)
    )
    dataset.pipeline.pop()
```

```
rank: 1, world_size: 8, {'url': 'source-000001.tar'}
rank: 5, world_size: 8, {'url': 'source-000005.tar'}
rank: 2, world_size: 8, {'url': 'source-000002.tar'}
rank: 4, world_size: 8, {'url': 'source-000004.tar'}
rank: 0, world_size: 8, {'url': 'source-000000.tar'}
rank: 3, world_size: 8, {'url': 'source-000003.tar'}
rank: 6, world_size: 8, {'url': 'source-000006.tar'}
rank: 7, world_size: 8, {'url': 'source-000007.tar'}
```

This is not necessarily bad. Thinking in favor of the existing approach, the GPU processes are going through samples in parallel, and it shouldn't really matter each specific GPU process gets a different shard across the same group of shards. In addition, having fixed set of shards for each rank encourages data caching during multi-node training, where each rank always gets the same set of shards, and perform shard shuffling if there are more than 1 item in the set of shards.

It's just a little unexpected during testing, because PyTorch has long been using this format, and the [ordering of the named params](https://github.com/webdataset/webdataset/blob/main/webdataset/compat.py#L95) - `shardshuffle` and `detshuffle` preceed `nodesplitter`, suggesting the same PyTorch-like behavior. So if it is desired to keep the existing behavior, it might help change the param order, and update the docs.