### PR TITLE
Fixup the docstring and argument list of all curried functions.

### DIFF
--- a/webdataset/filters.py
+++ b/webdataset/filters.py
@@ -16,6 +16,7 @@ from fnmatch import fnmatch
 import re
 import itertools, os, random, sys, time
 from functools import reduce
+import functools
 import pickle
 
 import numpy as np
@@ -69,6 +70,7 @@ def pipelinefilter(f):
     """Turn the decorated function into one that is partially applied for
     all arguments other than the first."""
     result = RestCurried(f)
+    functools.update_wrapper(result, f)
     return result
 
 


### PR DESCRIPTION
Currently when using WebDataset inside, say, Jupyter notebooks all the curried pipeline filters have the same generic (and quite confusing) docstrings and argument lists.

This patch uses `functools.update_wrapper` that is used for decorators in the standard library to improve upon this.

I think we could make it even better by making all the function docstrings longer and fit the RestCurried docstring in one line (maybe we cut convert the sentence explaining the "roundabout" into a comment?).

Before:
```
In [2]: wds.to_tuple?
Signature:      wds.to_tuple(*args, **kw)
Type:           RestCurried
String form:    <webdataset.filters.RestCurried object at 0x7fec7e9833d0>
File:           ~/workspace/webdataset/webdataset/filters.py
Docstring:
Helper class for currying pipeline stages.

We use this roundabout construct because it can be pickled.
Init docstring: Store the function for future currying.
Call docstring: Curry with the given arguments.
```

After:
```
In [5]: wds.to_tuple?
Signature:
wds.to_tuple(
    data,
    *args,
    handler=<function reraise_exception at 0x7f7f0385eb90>,
    missing_is_error=True,
    none_is_error=None,
)
Call signature:  wds.to_tuple(*args, **kw)
Type:            RestCurried
String form:     <webdataset.filters.RestCurried object at 0x7f7fb6913a30>
File:            ~/workspace/webdataset/webdataset/filters.py
Docstring:       Convert dict samples to tuples.
Class docstring:
Helper class for currying pipeline stages.

We use this roundabout construct because it can be pickled.
Init docstring:  Store the function for future currying.
Call docstring:  Curry with the given arguments.
```