### PR TITLE
Report the __url__ and __key__ for autodecoding errors

### DIFF
--- a/webdataset/autodecode.py
+++ b/webdataset/autodecode.py
@@ -473,6 +473,8 @@ def gzfilter(key, data):
 default_pre_handlers = [gzfilter]
 default_post_handlers = [basichandlers]
 
+class DecodingError(Exception):
+    pass
 
 class Decoder:
     """Decode samples using a list of handlers.
@@ -527,26 +529,31 @@ class Decoder:
         result = {}
         assert isinstance(sample, dict), sample
         for k, v in list(sample.items()):
-            if k[0:2] == "__":
-                if isinstance(v, bytes):
-                    try:
-                        v = v.decode("utf-8")
-                    except:
-                        print(f"Can't decode v of k = {k} as utf-8: v = {v}")
-                result[k] = v
-                continue
-            if self.only is not None and k not in self.only:
-                result[k] = v
-                continue
-            assert v is not None
-            if self.partial:
-                if isinstance(v, bytes):
-                    result[k] = self.decode1(k, v)
-                else:
+            try:
+                if k[0:2] == "__":
+                    if isinstance(v, bytes):
+                        try:
+                            v = v.decode("utf-8")
+                        except:
+                            print(f"Can't decode v of k = {k} as utf-8: v = {v}")
                     result[k] = v
-            else:
-                assert isinstance(v, bytes), f"k,v = {k}, {v}"
-                result[k] = self.decode1(k, v)
+                    continue
+                if self.only is not None and k not in self.only:
+                    result[k] = v
+                    continue
+                assert v is not None
+                if self.partial:
+                    if isinstance(v, bytes):
+                        result[k] = self.decode1(k, v)
+                    else:
+                        result[k] = v
+                else:
+                    assert isinstance(v, bytes), f"k,v = {k}, {v}"
+                    result[k] = self.decode1(k, v)
+            except Exception as exc:
+                new_exc = DecodingError({'__url__': sample.get('__url__', None), '__key__': sample.get('__key__', None), 'key': k})
+                new_exc.sample = sample
+                raise new_exc from exc
         return result
 
     def __call__(self, sample):


### PR DESCRIPTION
Right now decoding errors are not reporting much information about what happened. It makes finding and fixing the invalid data quite hard. I think it would be great to improve this and I provide one such proposal in this PR but I am open to discuss (and implement) other ways of fixing this.

In case of any decoding error the proposed patch would create a new exception (keeping the original one as `.__context__` for reference) with the `__url__`, `__key__` from the sample and the offending key name. You can also catch these errors in `handler` and log just the interesting info (there is a `sample` attribute on the exception that allows you to inspect the sample before the failed decoding) but a default traceback would already give you most of the important info:

```
DecodingError: Caught DecodingError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/root/workspace/webdataset/webdataset/autodecode.py", line 552, in decode
    result[k] = self.decode1(k, v)
  File "/root/workspace/webdataset/webdataset/autodecode.py", line 516, in decode1
    result = f(key, data)
  File "/root/workspace/webdataset/webdataset/autodecode.py", line 424, in torch_audio
    return torchaudio.load(fname)
  File "/opt/conda/lib/python3.10/site-packages/torchaudio/backend/soundfile_backend.py", line 221, in load
    with soundfile.SoundFile(filepath, "r") as file_:
  File "/opt/conda/lib/python3.10/site-packages/soundfile.py", line 658, in __init__
    self._file = self._open(file, mode_int, closefd)
  File "/opt/conda/lib/python3.10/site-packages/soundfile.py", line 1216, in _open
    raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
soundfile.LibsndfileError: Error opening '/tmp/tmpsexbhodx/file.mp3': File does not exist or is not a regular file (possibly a pipe?).

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/torch/utils/data/_utils/worker.py", line 308, in _worker_loop
    data = fetcher.fetch(index)
  File "/opt/conda/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 41, in fetch
    data = next(self.dataset_iter)
  File "/root/workspace/webdataset/webdataset/pipeline.py", line 64, in iterator
    for sample in self.iterator1():
  File "/root/workspace/webdataset/webdataset/filters.py", line 301, in _map
    if handler(exn):
  File "/root/workspace/webdataset/webdataset/filters.py", line 80, in reraise_exception
    raise exn
  File "/root/workspace/webdataset/webdataset/filters.py", line 299, in _map
    result = f(sample)
  File "/root/workspace/webdataset/webdataset/autodecode.py", line 565, in __call__
    return self.decode(sample)
  File "/root/workspace/webdataset/webdataset/autodecode.py", line 556, in decode
    raise new_exc from exc
webdataset.autodecode.DecodingError: {'__url__': './guttenberg-audiobooks-raw-000010.tar', '__key__': 'synapseml_gutenberg_the_firefly_of_france_by_marion_polk_ang', 'key': 'mp3'}
```

I think there is a potential backwards incompatibility for people who expect to filter for specific exceptions in their custom `handler` functions. With  this PR they would get a `DecodingError` with the original exception waiting to be unpacked from the `__context__` attribute which would break any code which, for example, runs `isinstance` on the exception.
Maybe it would be worth the trouble to add some code to always pass the original exception to the handler and optionally add the wrapped one as an optional keyword argument? OTOH this would complicate the "happy path" quite a bit and would probably make it quite confusing for new users.

Another approach would be to stuff the additional information into the original exception and modify the default handlers so it is printed by default (but then you will always get a printout even if you catch the exception unless you modify the handler).