### PR TITLE
Close the stream to avoid the ResourceWarning

### DIFF
--- a/webdataset/tariterators.py
+++ b/webdataset/tariterators.py
@@ -190,6 +190,8 @@ def tar_file_expander(
                 continue
             else:
                 break
+        # Close the stream
+        source["stream"].close()
 
 
 def group_by_keys(


### PR DESCRIPTION
The stream is deleted but not be closed which will cause ResourceWarning.