### PR TITLE
add hf datasets in supported libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ There are several libraries supporting the WebDataset format:
 - [Webdataset.jl](https://github.com/webdataset/WebDataset.jl) a Julia implementation
 - [tarp](https://github.com/webdataset/tarp), a Golang implementation and command line tool
 - Ray Data sources and sinks
+- Hugging Face [datasets](https://github.com/huggingface/datasets) library
 
 The `webdataset` library can be used with PyTorch, Tensorflow, and Jax.
 


### PR DESCRIPTION
WebDataset format support was added in `datasets` [2.16.0](https://github.com/huggingface/datasets/releases/tag/2.16.0)

e.g.

```python
from datasets import load_dataset

# Load dataset at https://huggingface.co/datasets/pixparse/cc12m-wds
ds = load_dataset("pixparse/cc12m-wds", streaming=True)

for example in ds["train"]:
    ...
```