### PR TITLE
Add missing import in utils

### DIFF
--- a/webdataset/utils.py
+++ b/webdataset/utils.py
@@ -15,7 +15,7 @@ import os
 import re
 import sys
 import warnings
-from typing import Any, Callable, Iterator, Union
+from typing import Any, Callable, Iterable, Iterator, Union
 
 import numpy as np
 


### PR DESCRIPTION
Iterable is used in the is_iterable function, but the import is missing