### PR TITLE
seed is not used in _shuffle()

### DIFF
--- a/webdataset/filters.py
+++ b/webdataset/filters.py
@@ -209,7 +209,7 @@ def _shuffle(data, bufsize=1000, initial=100, rng=None, seed=None, handler=None)
     """
     if seed is not None:
         assert rng is None
-        rng = random.Random(rng)
+        rng = random.Random(seed)
     elif rng is None:
         rng = random.Random(int((os.getpid() + time.time()) * 1e9))
     initial = min(initial, bufsize)


### PR DESCRIPTION
Hi,

This PR is to fix `seed` is not used in `_shuffle()`. This causes dataloaders on the same dataset in different processes are not returning the same indices, which is not desired if we give a seed to it. 

To reproduce the problem at the current release ([0.2.88](https://github.com/webdataset/webdataset/releases/tag/0.2.88)):
```
import os
import random
import numpy as np
import webdataset as wds
import torch
import torch.distributed as dist
from torch import default_generator
from torch.utils.data import TensorDataset

col_1 = TensorDataset(torch.arange(0, 1000))
col_2 = TensorDataset(torch.arange(0, 1000))
col_3 = TensorDataset(torch.arange(0, 1000))
ds = [col_1, col_2, col_3]

def seed_everything(seed):
    os.environ["PYTHON_SEED"] = str(seed)
    random.seed(seed)
    np.random.seed(seed)
    torch.manual_seed(seed)

def ddp_setup():
    dist.init_process_group()

def ddp_cleanup():
    dist.destroy_process_group()

def ddp_main():
    ddp_setup()
    rank, world_size = dist.get_rank(), dist.get_world_size()
    
    loaders = [
        wds.WebLoader(
            col,
            batch_size=None,
            generator=default_generator,
        ).shuffle(25, seed=rank)
        .batched(8)
        for col in ds
    ]

    for i, data in enumerate(zip(*loaders)):
        print (f"proc-{rank}: {data}")
        if i > 1:
            break

def main():
    seed_everything(0)
    ddp_main()

if __name__ == "__main__":
    main()

```

And below is the output I got, before and after my fix:

```
# ----------------before------------------
torchrun --nproc_per_node 2 --nnodes 1 --rdzv_backend c10d --rdzv_endpoint localhost:0 --master_addr=localhost wds_shuffle_bug.py
proc-0: ([tensor([ 6,  7, 25, 16,  5, 12, 11, 19])], [tensor([13, 25,  6, 20, 19, 24, 26,  4])], [tensor([ 5, 25, 13, 20, 22,  4,  6, 12])])
proc-1: ([tensor([16,  8, 18, 19,  4,  9, 12, 15])], [tensor([ 1, 20, 11,  9, 12, 18, 17, 16])], [tensor([17,  3, 19,  7, 22,  2, 29, 16])])
proc-0: ([tensor([32,  4,  9,  2, 15, 18, 20, 37])], [tensor([ 8, 30, 27, 16, 35,  0, 21, 14])], [tensor([30,  9, 15, 19,  2, 21,  1, 36])])
proc-1: ([tensor([13, 20,  6, 35, 32, 14,  5, 30])], [tensor([27, 31, 33, 26, 23, 14, 10, 36])], [tensor([14, 21,  1, 35, 25,  0, 38, 12])])
proc-0: ([tensor([10, 13, 23, 39, 26,  3, 46, 45])], [tensor([12, 41, 23,  1,  7, 15, 32, 47])], [tensor([37, 28, 14, 29, 43, 10, 40, 23])])
proc-1: ([tensor([31, 33, 36, 41,  0, 34, 43, 24])], [tensor([ 5, 22,  2, 30, 35,  7, 21,  4])], [tensor([20, 24, 26,  9, 32,  4, 34, 37])])

# ----------------after------------------
torchrun --nproc_per_node 2 --nnodes 1 --rdzv_backend c10d --rdzv_endpoint localhost:0 --master_addr=localhost wds_shuffle_bug.py
proc-0: ([tensor([12, 25, 13,  1,  8, 16, 15, 24])], [tensor([12, 25, 13,  1,  8, 16, 15, 24])], [tensor([12, 25, 13,  1,  8, 16, 15, 24])])
proc-1: ([tensor([ 4, 18, 26,  2,  8,  3, 15, 31])], [tensor([ 4, 18, 26,  2,  8,  3, 15, 31])], [tensor([ 4, 18, 26,  2,  8,  3, 15, 31])])
proc-0: ([tensor([ 9, 30, 11, 18,  6, 29,  4, 32])], [tensor([ 9, 30, 11, 18,  6, 29,  4, 32])], [tensor([ 9, 30, 11, 18,  6, 29,  4, 32])])
proc-1: ([tensor([14, 30, 20, 12,  6, 29, 33,  0])], [tensor([14, 30, 20, 12,  6, 29, 33,  0])], [tensor([14, 30, 20, 12,  6, 29, 33,  0])])
proc-0: ([tensor([38, 41,  3, 19, 28, 17, 22, 43])], [tensor([38, 41,  3, 19, 28, 17, 22, 43])], [tensor([38, 41,  3, 19, 28, 17, 22, 43])])
proc-1: ([tensor([35, 13, 19, 43, 44, 39, 22, 32])], [tensor([35, 13, 19, 43, 44, 39, 22, 32])], [tensor([35, 13, 19, 43, 44, 39, 22, 32])])
```
