### PR TITLE
Delete redundant md5 calculation function

### DIFF
--- a/wids/wids.py
+++ b/wids/wids.py
@@ -70,20 +70,6 @@ def compute_file_md5sum(fname: Union[str, BinaryIO], chunksize: int = 1000000) -
     return md5.hexdigest()
 
 
-def compute_file_md5sum(fname: Union[str, BinaryIO], chunksize: int = 1000000) -> str:
-    """Compute the md5sum of a file in chunks."""
-    md5 = hashlib.md5()
-    if isinstance(fname, str):
-        with open(fname, "rb") as f:
-            for chunk in iter(lambda: f.read(chunksize), b""):
-                md5.update(chunk)
-    else:
-        fname.seek(0)
-        for chunk in iter(lambda: fname.read(chunksize), b""):
-            md5.update(chunk)
-    return md5.hexdigest()
-
-
 def compute_num_samples(fname):
     ds = IndexedTarSamples(fname)
     return len(ds)


### PR DESCRIPTION
There seem to be two md5 calculation functions with exactly the same functionality