### PR TITLE
Fix: Minor bug in writer.py opener missing self

### DIFF
--- a/webdataset/writer.py
+++ b/webdataset/writer.py
@@ -438,7 +438,7 @@ class ShardWriter:
             )
         self.shard += 1
         if self.opener:
-            self.tarstream = TarWriter(opener(self.fname), **self.kw)
+            self.tarstream = TarWriter(self.opener(self.fname), **self.kw)
         else:
             self.tarstream = TarWriter(self.fname, **self.kw)
         self.count = 0


### PR DESCRIPTION
###Description
* webdataset/writer.py: Add self to opener call in ShardWriter

###Motivation
* ShardWriter broken when using an opener