### PR TITLE
feat: add __len__ to ChunkedSampler to work with pytorch lightning

### DIFF
--- a/wids/wids.py
+++ b/wids/wids.py
@@ -2,6 +2,7 @@ import base64
 import gzip
 import hashlib
 import io
+import math
 import os
 import random
 import re
@@ -680,6 +681,7 @@ class ChunkedSampler(Sampler):
         self,
         dataset,
         *,
+        dslength_per_replica=-1,
         num_samples=None,
         chunksize=2000,
         seed=0,
@@ -692,6 +694,11 @@ class ChunkedSampler(Sampler):
             lo, hi = 0, len(dataset)
         else:
             lo, hi = num_samples
+
+        self.dslength_per_replica = (
+            dslength_per_replica if dslength_per_replica > 0 else (hi - lo)
+        )
+
         self.ranges = [(i, min(i + chunksize, hi)) for i in range(lo, hi, chunksize)]
         self.seed = seed
         self.shuffle = shuffle
@@ -711,6 +718,9 @@ class ChunkedSampler(Sampler):
             shardshuffle=(self.shuffle and shardshuffle),
         )
         self.epoch += 1
+
+    def __len__(self) -> int:
+        return self.dslength_per_replica
 
 
 def DistributedChunkedSampler(
@@ -748,12 +758,18 @@ def DistributedChunkedSampler(
         rank = rank or dist.get_rank()
     assert rank >= 0 and rank < num_replicas
 
+    # From https://github.com/pytorch/pytorch/blob/13fa59580e4dd695817ccf2f24922fd211667fc8/torch/utils/data/distributed.py#L93
+    dslength_per_replica = (
+        math.ceil(len(dataset) / num_replicas) if num_replicas > 1 else len(dataset)
+    )
+
     num_samples = num_samples or len(dataset)
     worker_chunk = (num_samples + num_replicas - 1) // num_replicas
     worker_start = rank * worker_chunk
     worker_end = min(worker_start + worker_chunk, num_samples)
     return ChunkedSampler(
         dataset,
+        dslength_per_replica=dslength_per_replica,
         num_samples=(worker_start, worker_end),
         chunksize=chunksize,
         seed=seed,


### PR DESCRIPTION
First of all thanks for the amazing `wids` library!

When training with pytorch lightning in a distributed setting, I got the following error:

```bash
[rank0]: TypeError: You seem to have configured a sampler in your DataLoader which does not provide `__len__` method. The sampler was about to be replaced by `DistributedSamplerWrapper` since `use_distributed_sampler` is True and you are using distributed training. Either provide `__len__` method in your sampler, remove it from DataLoader or set `use_distributed_sampler=False` if you want to handle distributed sampling yourself.
```

Setting `use_distributed_sampler=False` seems to work, but then we lose the information about how big the dataset is (and e.g. have an unknown progress bar length and cannot use epoch-features). Adding `__len__` fixes seems to work fine; I have performed several trainings successfully.

NOTE: In lightning, one needs to set `use_distributed_sampler=False` in the trainer. Otherwise, the WIDS-sampler gets replaced (without a verbose info).