### PR TITLE
Fix PipelineStage invocation inside DataPipeline.

### DIFF
--- a/webdataset/pipeline.py
+++ b/webdataset/pipeline.py
@@ -46,10 +46,10 @@ class DataPipeline(IterableDataset, PipelineStage):
 
     def invoke(self, f, *args, **kwargs):
         """Apply a pipeline stage, possibly to the output of a previous stage."""
-        if isinstance(f, PipelineStage):
-            return f.run(*args, **kwargs)
         if isinstance(f, (IterableDataset, DataLoader)) and len(args) == 0:
             return iter(f)
+        if isinstance(f, PipelineStage):
+            return f.run(*args, **kwargs)
         if isinstance(f, list):
             return iter(f)
         if callable(f):


### PR DESCRIPTION
Minor fix to resolve issue with nested DataPipelines. If DataPipeline is passed to FluidWrapper (assuming it was used in place of some IterableDataset) it will cause an error since DataPipeline is a PipelineStage, but doesn't have run method. Switching checks order helps to deal with it.