### PR TITLE
fix: NameError: name 'Iterable' is not defined.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,3 +11,23 @@ def test_repeatedly2():
 
 def test_repeatedly3():
     assert len(list(utils.repeatedly([[[1, 1], [2, 2]]] * 3, nsamples=10))) == 5
+
+
+def test_is_iterable():
+
+    sample_string = "sample_string"
+    sample_bytes = b"sample_bytes"
+    sample_list = [1, 2, 3, 4, 5]
+    sample_iter = iter(sample_list)
+
+    def gen_func():
+        for i in range(5):
+            yield i
+
+    sample_generator = gen_func()
+
+    assert utils.is_iterable(sample_string) is False, "String should not be iterable"
+    assert utils.is_iterable(sample_bytes) is False, "Bytes should not be iterable"
+    assert utils.is_iterable(sample_list) is True, "List should be iterable"
+    assert utils.is_iterable(sample_iter) is True, "Iterator should be iterable"
+    assert utils.is_iterable(sample_generator) is True, "Generator should be iterable"

--- a/webdataset/utils.py
+++ b/webdataset/utils.py
@@ -15,7 +15,7 @@ import os
 import re
 import sys
 import warnings
-from typing import Any, Callable, Iterator, Union
+from typing import Any, Callable, Iterable, Union
 
 import numpy as np
 
@@ -43,17 +43,12 @@ def make_seed(*args):
 
 
 def is_iterable(obj):
-    if isinstance(obj, str):
+    """
+    Return `True` if the object is iterable, with the exception of strings and bytes.
+    """
+    if isinstance(obj, (str, bytes)):
         return False
-    if isinstance(obj, bytes):
-        return False
-    if isinstance(obj, list):
-        return True
-    if isinstance(obj, Iterator):
-        return True
-    if isinstance(obj, Iterable):
-        return True
-    return False
+    return isinstance(obj, Iterable)
 
 
 class PipelineStage:


### PR DESCRIPTION
This PR fixes a breaking issue faced during the following instantiation on version `0.2.100`

Minimal reproducible code

```py
from webdataset import SimpleShardList, WebDataset

shard_list = SimpleShardList(str(shard_file))
dataset = WebDataset(shard_list)
```

Error log

```sh
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/dantremonti/miniconda3/envs/lock-update/lib/python3.10/site-packages/webdataset/compat.py", line 145, in __init__
    self.create_url_iterator(args)
  File "/home/dantremonti/miniconda3/envs/lock-update/lib/python3.10/site-packages/webdataset/compat.py", line 226, in create_url_iterator
    if isinstance(args.urls, str) or utils.is_iterable(args.urls):
  File "/home/dantremonti/miniconda3/envs/lock-update/lib/python3.10/site-packages/webdataset/utils.py", line 54, in is_iterable
    if isinstance(obj, Iterable):
NameError: name 'Iterable' is not defined
```

Also introduces a test for the fixed utility function. Fixes #389 