### PR TITLE
Fix NameError, forgot to import Iterable

### DIFF
--- a/webdataset/utils.py
+++ b/webdataset/utils.py
@@ -15,7 +15,7 @@ import os
 import re
 import sys
 import warnings
-from typing import Any, Callable, Iterator, Union
+from typing import Any, Callable, Iterator, Iterable, Union
 
 import numpy as np
 


### PR DESCRIPTION
I encountered an error when working with webdataset. The `is_iterable` function in `webdataset/utils.py` (line 54) checks that the object type matches the `Iterable` type, but `Iterable` was not imported.