### PR TITLE
Fix typo of DirectoryShardList in compat.py

### DIFF
--- a/webdataset/compat.py
+++ b/webdataset/compat.py
@@ -219,7 +219,7 @@ class WebDataset(DataPipeline, FluidInterface):
 
         # any URL ending in "/" is assumed to be a directory
         if isinstance(urls, str) and urlparse(urls).path.endswith("/"):
-            self.append(shardlists.DirectoryShardlist(urls, mode=args.mode))
+            self.append(shardlists.DirectoryShardList(urls, mode=args.mode))
             return
 
         # the rest is either a shard list or a resampled shard list


### PR DESCRIPTION
compat.py mentions:
> any URL ending in "/" is assumed to be a directory

Which I tried but resulted in:
```python
File "/[...]/.venv/lib/python3.10/site-packages/webdataset/compat.py", line 222, in create_url_iterator
    self.append(shardlists.DirectoryShardlist(urls, mode=args.mode))
AttributeError: module 'webdataset.shardlists' has no attribute 'DirectoryShardlist'. Did you mean: 'DirectoryShardList'?
```

This should do it! Thanks for a great lib as well 🤘🏽 