### PR TITLE
Fix additional slash error in Windows pathes

### DIFF
--- a/webdataset/gopen.py
+++ b/webdataset/gopen.py
@@ -10,6 +10,7 @@ import re
 import sys
 from subprocess import PIPE, Popen
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 # global used for printing additional node information during verbose output
 info = {}
@@ -502,7 +503,7 @@ def gopen(url, mode="rb", bufsize=8192, **kw):
         return open(url, mode, buffering=bufsize)
     if pr.scheme == "file":
         bufsize = int(os.environ.get("GOPEN_BUFFER", -1))
-        return open(pr.path, mode, buffering=bufsize)
+        return open(url2pathname(pr.path), mode, buffering=bufsize)
     handler = gopen_schemes["__default__"]
     handler = gopen_schemes.get(pr.scheme, handler)
     return handler(url, mode, bufsize, **kw)


### PR DESCRIPTION
If you pass a default `file://C:/some/path` URL (e.g. one generated by `pathlib.as_uri()` function), and not a custom `file:C:/some/path` URL, it throws an error `OSError: [Errno 22] Invalid argument: '/C:/some/path` because `pr.path` returns a path with additional slash at the beginning of the path
Adding the `url2pathname` function solves this problem and can possibly solve come other path-related issues.