### PR TITLE
Missing import prevents iterable objects from being used as url source.

### DIFF
--- a/webdataset/shardlists.py
+++ b/webdataset/shardlists.py
@@ -27,7 +27,7 @@ import yaml
 from . import utils
 from .filters import pipelinefilter
 from .pytorch import IterableDataset
-from .utils import obsolete
+from .utils import is_iterable, obsolete
 
 
 def envlookup(m):


### PR DESCRIPTION
The following iterator would be helpful to use to filter out missing shards:

```
class ShardExistsFilter(Iterator[str]):
    """Simple iterator that filters out shards that don't exist."""

    def __init__(self, url: str):
        """
        :param url: URL pattern to expand. E.g. /some/path/{000000..000019}.tar
        """
        self.url_generator = filter(os.path.exists, braceexpand.braceexpand(url))

    def __next__(self) -> Any:
        return self.url_generator.__next__()
```

Because of the missing import, we are limited to url strings.