### PR TITLE
Update wids to handle local tars efficiently without copying them to cache

### DIFF
--- a/wids/wids_dl.py
+++ b/wids/wids_dl.py
@@ -126,14 +126,18 @@ def download_file(remote, local, handlers=default_cmds, verbose=False):
 
 def download_and_open(remote, local, mode="rb", handlers=default_cmds, verbose=False):
     with ULockFile(local + ".lock"):
-        if not os.path.exists(local):
-            if verbose:
-                print("downloading", remote, "to", local, file=sys.stderr)
-            download_file(remote, local, handlers=handlers)
+        # we make sure that it is a url and not a strng path to the dataset on local machine
+        if not os.path.exists(remote):
+            if not os.path.exists(local):
+                if verbose:
+                    print("downloading", remote, "to", local, file=sys.stderr)
+                download_file(remote, local, handlers=handlers)
+            else:
+                if verbose:
+                    print("using cached", local, file=sys.stderr)
+            result = open(local, mode)
         else:
-            if verbose:
-                print("using cached", local, file=sys.stderr)
-        result = open(local, mode)
+            result = open(remote, mode)
         if open_objects is not None:
             for k, v in list(open_objects.items()):
                 if v.closed:


### PR DESCRIPTION
wids handles local datasets, but it copies them to the /tmp folder, which can be inefficient if the dataset is already stored on your machine. To avoid unnecessary copying, we first check whether the dataset exists locally. If it does, we open it directly, otherwise, it is downloaded and saved to the /tmp folder.