### PR TITLE
Fix `wids.ShardListDataset.check_cache_misses()` warning formatting

### DIFF
--- a/wids/wids.py
+++ b/wids/wids.py
@@ -471,8 +471,8 @@ class ShardListDataset(Dataset[T]):
             # output a warning only once
             self.check_cache_misses = lambda: None
             print(
-                "Warning: ShardListDataset has a cache miss rate of {:.1%}%".format(
-                    misses * 100.0 / accesses
+                "Warning: ShardListDataset has a cache miss rate of {:.1%}".format(
+                    misses / accesses
                 )
             )
 


### PR DESCRIPTION
The format specifier `{:.1%}` already handles the conversion into a percentage by multiplying it by 100 and appending a `%` sign. This PR removed the extraneous conversion, fixing the printed warning.

Current warning:
```bash
Warning: ShardListDataset has a cache miss rate of 9802.0%%
```

Fixed formatting:
```bash
Warning: ShardListDataset has a cache miss rate of 98.0%
```