### PR TITLE
[Docs] Diagram visualization of webdataset's codebase

### DIFF
--- a/.codeboarding/Data_Ingestion_Layer.md
+++ b/.codeboarding/Data_Ingestion_Layer.md
@@ -1,0 +1,91 @@
+```mermaid
+
+graph LR
+
+    Shard_List_Manager["Shard List Manager"]
+
+    Generalized_I_O_Handler["Generalized I/O Handler"]
+
+    Data_Cache["Data Cache"]
+
+    Shard_List_Manager -- "provides URLs/paths to" --> Generalized_I_O_Handler
+
+    Generalized_I_O_Handler -- "interacts with" --> Data_Cache
+
+    Data_Cache -- "intercepts and stores/retrieves data streams from" --> Generalized_I_O_Handler
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The Data Ingestion Layer in `webdataset` is a critical subsystem responsible for efficiently accessing raw data shards from diverse sources. It acts as the initial gateway for data entering the processing pipeline, abstracting away the complexities of data location and access.
+
+
+
+### Shard List Manager
+
+This component is responsible for generating, expanding, and managing the list of data shard URLs or paths. It handles various input formats, including glob patterns and brace expansion, to produce a concrete list of data sources. It also provides mechanisms for distributing these shard lists across multiple workers or nodes, which is essential for parallel and distributed data loading in deep learning.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/shardlists.py" target="_blank" rel="noopener noreferrer">`webdataset.shardlists`</a>
+
+
+
+
+
+### Generalized I/O Handler
+
+This component provides a unified and abstracted interface for opening data streams from various sources, including local files, remote HTTP/HTTPS URLs, and potentially other cloud storage protocols. It encapsulates the logic for handling different I/O backends, allowing the rest of the data pipeline to interact with data sources uniformly, regardless of their origin.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/gopen.py#L523-L590" target="_blank" rel="noopener noreferrer">`webdataset.gopen` (523:590)</a>
+
+
+
+
+
+### Data Cache
+
+This component implements caching mechanisms, specifically an LRU (Least Recently Used) file cache, to store frequently accessed data shards locally. By intercepting I/O requests and serving data from the cache when available, it significantly reduces redundant network or disk I/O operations, thereby improving data loading performance, especially in scenarios with repeated data access or distributed training.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/cache.py" target="_blank" rel="noopener noreferrer">`webdataset.cache`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data_Output_Writer.md
+++ b/.codeboarding/Data_Output_Writer.md
@@ -1,0 +1,89 @@
+```mermaid
+
+graph LR
+
+    TarWriter["TarWriter"]
+
+    ShardWriter["ShardWriter"]
+
+    Generalized_I_O_Handler["Generalized I/O Handler"]
+
+    ShardWriter -- "uses" --> TarWriter
+
+    TarWriter -- "uses" --> Generalized_I_O_Handler
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `webdataset.writer` module is central to the `Data Output/Writer` component, handling the serialization of processed data into WebDataset (TAR) format.
+
+
+
+### TarWriter
+
+This component is responsible for the low-level writing of individual data samples (represented as dictionaries) into a single `.tar` or compressed `.tar.gz` file. It manages the encoding of various data types (e.g., images, audio, text) into byte streams suitable for TAR archiving, including handling metadata and file properties. It acts as the core serialization engine for a single archive.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/writer.py#L329-L484" target="_blank" rel="noopener noreferrer">`webdataset.writer.TarWriter` (329:484)</a>
+
+
+
+
+
+### ShardWriter
+
+This component orchestrates the creation of multiple sharded `.tar` files. It manages the logic for splitting the output data into new archives based on configurable limits, such as the maximum number of records or the maximum file size per shard. It utilizes the `TarWriter` for the actual writing operations to each individual shard.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/writer.py#L487-L600" target="_blank" rel="noopener noreferrer">`webdataset.writer.ShardWriter` (487:600)</a>
+
+
+
+
+
+### Generalized I/O Handler
+
+This component (represented by `webdataset.gopen`) handles opening output file streams, allowing writing to local files, network streams, or other supported destinations. It provides a unified interface for various file system operations, abstracting away the underlying storage mechanism.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/gopen.py#L523-L590" target="_blank" rel="noopener noreferrer">`webdataset.gopen` (523:590)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data_Processing_Core.md
+++ b/.codeboarding/Data_Processing_Core.md
@@ -1,0 +1,135 @@
+```mermaid
+
+graph LR
+
+    Tar_Record_Iterator["Tar Record Iterator"]
+
+    Automatic_Decoder["Automatic Decoder"]
+
+    Data_Transformer_Filter["Data Transformer & Filter"]
+
+    Data_Mixer["Data Mixer"]
+
+    Data_Processing_Core["Data Processing Core"]
+
+    Tar_Record_Iterator -- "feeds raw records to" --> Data_Processing_Core
+
+    Data_Processing_Core -- "utilizes" --> Automatic_Decoder
+
+    Data_Processing_Core -- "applies operations from" --> Data_Transformer_Filter
+
+    Data_Processing_Core -- "applies operations from" --> Data_Mixer
+
+    click Data_Processing_Core href "https://github.com/webdataset/webdataset/blob/main/.codeboarding//Data_Processing_Core.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### Tar Record Iterator
+
+This component is responsible for the initial extraction of individual data samples (records) from raw TAR archives. It acts as the first stage in the data processing pipeline, providing a stream of raw byte-level data entries.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/tariterators.py#L1-L1" target="_blank" rel="noopener noreferrer">`webdataset/tariterators.py` (1:1)</a>
+
+
+
+
+
+### Automatic Decoder
+
+This component intelligently decodes raw byte streams into usable Python data types, such as images (Pillow, PyTorch tensors), audio, text, or other structured data. It handles various encoding formats automatically.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/autodecode.py#L1-L1" target="_blank" rel="noopener noreferrer">`webdataset/autodecode.py` (1:1)</a>
+
+
+
+
+
+### Data Transformer & Filter
+
+This component provides a collection of functions and classes for applying various transformations and filters to the decoded data samples. Transformations can include resizing, normalization, augmentation (e.g., random crops, flips), while filters can be used to remove corrupted or unwanted samples.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/filters.py#L1-L1" target="_blank" rel="noopener noreferrer">`webdataset/filters.py` (1:1)</a>
+
+
+
+
+
+### Data Mixer
+
+This component offers functionalities for combining or mixing data samples, either from different sources or within the same stream. This can involve strategies like batch mixing, sample-level mixing (e.g., Mixup, CutMix), or creating composite samples.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/mix.py#L1-L1" target="_blank" rel="noopener noreferrer">`webdataset/mix.py` (1:1)</a>
+
+
+
+
+
+### Data Processing Core [[Expand]](./Data_Processing_Core.md)
+
+This is the central orchestration component that defines and manages the sequence of data processing operations. It allows chaining various stages like `Tar Record Iterator`, `Automatic Decoder`, `Data Transformer & Filter`, and `Data Mixer` to form a complete data loading pipeline. It ensures efficient and correct data flow within the `webdataset` library.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/pipeline.py#L1-L1" target="_blank" rel="noopener noreferrer">`webdataset/pipeline.py` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Pipeline_Orchestration_API.md
+++ b/.codeboarding/Pipeline_Orchestration_API.md
@@ -1,0 +1,71 @@
+```mermaid
+
+graph LR
+
+    Fluent_API_Facade["Fluent API Facade"]
+
+    Pipeline_Core_Logic["Pipeline Core Logic"]
+
+    Fluent_API_Facade -- "Configures" --> Pipeline_Core_Logic
+
+    Fluent_API_Facade -- "Initiates Execution" --> Pipeline_Core_Logic
+
+    Pipeline_Core_Logic -- "Provides Iterators" --> Fluent_API_Facade
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Component overview for `Pipeline Orchestration & API`, focusing on its structure, flow, and purpose within the `webdataset` project.
+
+
+
+### Fluent API Facade
+
+This component provides the high-level, chainable (fluent) interface that users interact with to declaratively define data loading and processing pipelines. It abstracts the complexities of underlying data iterators and pipeline stages, offering a user-friendly and intuitive way to construct `webdataset` pipelines. Classes like `WebDataset` and `WebLoader` serve as primary entry points, inheriting from `FluidInterface` to enable method chaining.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `FluidInterface`
+
+- `FluidWrapper`
+
+- `WebDataset`
+
+- `WebLoader`
+
+
+
+
+
+### Pipeline Core Logic
+
+This component is responsible for the internal orchestration and execution of the data pipeline. It takes the sequence of operations defined by the Fluent API Facade and manages the flow of data through various processing stages. It ensures efficient iteration, transformation, and handling of samples, effectively implementing the pipeline execution based on the user's configuration.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,163 @@
+```mermaid
+
+graph LR
+
+    Data_Ingestion_Layer["Data Ingestion Layer"]
+
+    Data_Processing_Core["Data Processing Core"]
+
+    Pipeline_Orchestration_API["Pipeline Orchestration & API"]
+
+    Data_Output_Writer["Data Output/Writer"]
+
+    Internal_Data_Utilities["Internal Data Utilities"]
+
+    Data_Ingestion_Layer -- "provides raw data streams to" --> Data_Processing_Core
+
+    Pipeline_Orchestration_API -- "configures and initiates" --> Data_Ingestion_Layer
+
+    Data_Processing_Core -- "consumes raw data streams from" --> Data_Ingestion_Layer
+
+    Data_Processing_Core -- "produces processed data samples for" --> Pipeline_Orchestration_API
+
+    Data_Processing_Core -- "utilizes for decoding operations" --> Internal_Data_Utilities
+
+    Pipeline_Orchestration_API -- "orchestrates and consumes processed samples from" --> Data_Processing_Core
+
+    Data_Output_Writer -- "utilizes for efficient data encoding" --> Internal_Data_Utilities
+
+    Internal_Data_Utilities -- "supports for decoding raw data" --> Data_Processing_Core
+
+    Internal_Data_Utilities -- "supports for encoding data to TAR" --> Data_Output_Writer
+
+    click Data_Ingestion_Layer href "https://github.com/webdataset/webdataset/blob/main/.codeboarding//Data_Ingestion_Layer.md" "Details"
+
+    click Data_Processing_Core href "https://github.com/webdataset/webdataset/blob/main/.codeboarding//Data_Processing_Core.md" "Details"
+
+    click Pipeline_Orchestration_API href "https://github.com/webdataset/webdataset/blob/main/.codeboarding//Pipeline_Orchestration_API.md" "Details"
+
+    click Data_Output_Writer href "https://github.com/webdataset/webdataset/blob/main/.codeboarding//Data_Output_Writer.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+A high-level data flow overview of `webdataset`, focusing on its central modules and their interactions, aligned with typical Data Pipeline Library architecture.
+
+
+
+### Data Ingestion Layer [[Expand]](./Data_Ingestion_Layer.md)
+
+This component is responsible for identifying, locating, and opening data shards from various sources (local files, HTTP, cloud storage) and optionally caching them locally. It manages the initial access to raw data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/shardlists.py" target="_blank" rel="noopener noreferrer">`webdataset/shardlists.py`</a>
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/gopen.py" target="_blank" rel="noopener noreferrer">`webdataset/gopen.py`</a>
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/cache.py" target="_blank" rel="noopener noreferrer">`webdataset/cache.py`</a>
+
+
+
+
+
+### Data Processing Core [[Expand]](./Data_Processing_Core.md)
+
+The heart of the data pipeline, this component handles the extraction of individual samples from raw data streams (e.g., TAR archives), decodes raw byte streams into usable Python data types (images, tensors, text), and applies various transformations, augmentations, and mixing strategies to the data samples.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/tariterators.py" target="_blank" rel="noopener noreferrer">`webdataset/tariterators.py`</a>
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/autodecode.py" target="_blank" rel="noopener noreferrer">`webdataset/autodecode.py`</a>
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/filters.py" target="_blank" rel="noopener noreferrer">`webdataset/filters.py`</a>
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/mix.py" target="_blank" rel="noopener noreferrer">`webdataset/mix.py`</a>
+
+
+
+
+
+### Pipeline Orchestration & API [[Expand]](./Pipeline_Orchestration_API.md)
+
+This central component provides the framework for chaining together different data processing stages into a coherent, iterable data pipeline. It exposes a user-friendly, chainable API (Fluent API) for defining and configuring the pipeline, abstracting away the direct manipulation of underlying components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/pipeline.py" target="_blank" rel="noopener noreferrer">`webdataset/pipeline.py`</a>
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/compat.py" target="_blank" rel="noopener noreferrer">`webdataset/compat.py`</a>
+
+
+
+
+
+### Data Output/Writer [[Expand]](./Data_Output_Writer.md)
+
+This component manages the serialization of processed data samples back into the WebDataset (TAR) format. It handles encoding various data types and the creation of new TAR archives, potentially splitting them into multiple shards.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/writer.py" target="_blank" rel="noopener noreferrer">`webdataset/writer.py`</a>
+
+
+
+
+
+### Internal Data Utilities
+
+A foundational component providing low-level utilities for efficient binary encoding and decoding of data structures, particularly for numerical arrays and lists. It supports internal serialization and deserialization processes within the library.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/webdataset/webdataset/blob/main/src/webdataset/tenbin.py" target="_blank" rel="noopener noreferrer">`webdataset/tenbin.py`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
In this PR, I'm introducing diagram-first documentation for the codebase. You can preview the rendered markdown here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/webdataset/on_boarding.md

The goal is to help new contributors quickly understand the structure of the codebase. The diagram highlights key components, their interactions, and links to relevant source code—making it easier to focus on specific areas. Components are also clickable for more detailed exploration.

I noticed there's an open issue related to documentation: https://github.com/webdataset/webdataset/issues/452
This might be a helpful addition.

If it’s useful, we also offer a free GitHub Action to keep the docs automatically updated—happy to set that up for you.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.