### PR TITLE
Read environmental variables for deciding if to use cache or not

### DIFF
--- a/src/webdataset/compat.py
+++ b/src/webdataset/compat.py
@@ -405,10 +405,10 @@ class WebDataset(DataPipeline, FluidInterface):
 
         # next, we select a URL opener, either with or without caching
         # this generates a stream of dict(url=..., stream=...)
-        if cache_dir is None or cache_size == 0:
+        if args.cache_dir is None or args.cache_size == 0:
             opener = cache.StreamingOpen(handler=handler)
         else:
-            opener = cache.FileCache(cache_dir=cache_dir, cache_size=cache_size, handler=handler)
+            opener = cache.FileCache(cache_dir=args.cache_dir, cache_size=args.cache_size, handler=handler)
         self.append(opener)
 
         # now we need to open each stream and read the tar files contained in it


### PR DESCRIPTION
]The [WebDataset.update_cache_info(args)](https://github.com/webdataset/webdataset/blob/0773837ecd298587fc89c4f944ef346ef1a6b619/src/webdataset/compat.py#L428) method [never gets utilized](https://github.com/webdataset/webdataset/blob/0773837ecd298587fc89c4f944ef346ef1a6b619/src/webdataset/compat.py#L408) to pull cache_dir from the environment. Fixes this.