### PR TITLE
Add MultiModalWebDataset for loading from separate tar files per modality

### DIFF
--- a/docs/multimodal.md
+++ b/docs/multimodal.md
@@ -1,0 +1,368 @@
+# Multi-Modal WebDataset: Loading from Separate Tar Files
+
+## The Problem
+
+Standard WebDataset assumes all modalities for a sample (image, text, embedding, etc.)
+are interleaved within the same tar file:
+
+```
+shard_0000.tar
+  sample_000.jpg
+  sample_000.txt
+  sample_000.npy
+  sample_001.jpg
+  sample_001.txt
+  sample_001.npy
+  ...
+```
+
+Many real-world datasets instead store each modality in **separate tar directories**:
+
+```
+images/shard_0000.tar         embeddings/shard_0000.tar
+  sample_000.jpg                sample_000.emb.npy
+  sample_001.jpg                sample_001.emb.npy
+  ...                           ...
+images/shard_0001.tar         embeddings/shard_0001.tar
+  sample_002.jpg                sample_002.emb.npy
+  ...                           ...
+```
+
+Naively loading from separate pipelines and zipping them risks misalignment:
+independent shuffling, splitting across workers/nodes, or missing samples can
+cause images to be paired with the wrong embeddings.
+
+## The Solution: `MultiModalWebDataset`
+
+`MultiModalWebDataset` pairs shards across modalities **before** any splitting
+or shuffling occurs. Paired shard dicts flow through the pipeline as atomic units,
+guaranteeing alignment:
+
+```
+PairedShardList -> nodesplitter -> workersplitter -> shard shuffle -> PairedTarExpander -> samples
+```
+
+## Quick Start
+
+```python
+import webdataset as wds
+from torch.utils.data import DataLoader
+
+ds = wds.MultiModalWebDataset(
+    modalities={
+        "images": "/data/images/shard_{0000..0099}.tar",
+        "embeddings": "/data/embeddings/shard_{0000..0099}.tar",
+    },
+    shardshuffle=100,
+)
+
+for sample in ds:
+    print(sample["__key__"])      # e.g. "sample_0000_0001"
+    print(sample["jpg"])          # raw bytes from images tar
+    print(sample["emb.npy"])     # raw bytes from embeddings tar
+    break
+```
+
+All the same fluent chaining methods from `WebDataset` work:
+
+```python
+ds = wds.MultiModalWebDataset(
+    modalities={
+        "images": "/data/images/shard_{0000..0099}.tar",
+        "embeddings": "/data/embeddings/shard_{0000..0099}.tar",
+    },
+    shardshuffle=100,
+    detshuffle=True,
+    seed=42,
+).decode("rgb").to_tuple("jpg", "emb.npy").batched(32)
+
+for images, embeddings in DataLoader(ds, num_workers=4):
+    # images: list of numpy arrays (variable size) or tensor batch (fixed size)
+    # embeddings: list/tensor of numpy arrays
+    ...
+```
+
+## Constructor Parameters
+
+```python
+wds.MultiModalWebDataset(
+    modalities,           # dict[str, str | list] - modality name -> shard URL pattern
+    handler=...,          # exception handler (default: reraise_exception)
+    shardshuffle=...,     # int or False - shard shuffle buffer size
+    detshuffle=False,     # bool - deterministic shuffling for reproducibility
+    nodesplitter=...,     # function for distributed node splitting (default: single_node_only)
+    workersplitter=...,   # function for DataLoader worker splitting (default: split_by_worker)
+    select_files=None,    # optional predicate to filter files within tars
+    rename_files=None,    # optional function to rename files within tars
+    empty_check=True,     # raise ValueError if no samples found
+    seed=None,            # random seed for shuffling
+    missing_key_policy="skip",  # how to handle misaligned keys: "skip", "partial", "error"
+)
+```
+
+## URL Patterns
+
+Shard URLs support the same formats as `WebDataset`:
+
+```python
+# Brace expansion
+"images/shard_{0000..0099}.tar"
+
+# Explicit list
+["images/shard_0000.tar", "images/shard_0001.tar"]
+
+# Remote URLs via pipe:
+"pipe:aws s3 cp s3://bucket/images/shard_{0000..0099}.tar -"
+
+# Any scheme supported by gopen (http, https, gs, etc.)
+"https://storage.example.com/images/shard_{0000..0099}.tar"
+```
+
+**Requirement:** All modalities must have the **same number of shards**. Shards
+are paired by index (the first URL from each modality forms a group, the second
+URL from each forms the next group, etc.).
+
+## Handling Misaligned Keys
+
+Samples are matched across modalities by their `__key__` (the filename without
+extension). If some samples are missing from a modality, the `missing_key_policy`
+parameter controls behavior:
+
+### `"skip"` (default)
+
+Drop any sample not present in **all** modalities. This is the safest option.
+
+```python
+# images/shard has keys: a, b, c
+# embeddings/shard has keys: a, c
+# Result: only a, c are yielded (b is skipped)
+
+ds = wds.MultiModalWebDataset(
+    modalities={"images": ..., "embeddings": ...},
+    missing_key_policy="skip",  # default
+    shardshuffle=False,
+)
+```
+
+### `"partial"`
+
+Yield samples with whatever modalities are available. Useful when you want
+to handle missing data downstream.
+
+```python
+# images/shard has keys: a, b, c
+# embeddings/shard has keys: a, c
+# Result: a (both), b (images only), c (both)
+
+ds = wds.MultiModalWebDataset(
+    modalities={"images": ..., "embeddings": ...},
+    missing_key_policy="partial",
+    shardshuffle=False,
+)
+
+for sample in ds:
+    has_embedding = "emb.npy" in sample  # False for sample "b"
+```
+
+### `"error"`
+
+Raise `ValueError` immediately if any key mismatch is detected. Use this
+when your shards should be perfectly aligned and you want to catch data
+corruption.
+
+```python
+ds = wds.MultiModalWebDataset(
+    modalities={"images": ..., "embeddings": ...},
+    missing_key_policy="error",
+    shardshuffle=False,
+)
+
+# Raises ValueError: "key mismatch across modalities: images='b', embeddings='c'"
+list(ds)
+```
+
+## Three or More Modalities
+
+Works with any number of modalities:
+
+```python
+ds = wds.MultiModalWebDataset(
+    modalities={
+        "images": "/data/images/shard_{0000..0099}.tar",
+        "embeddings": "/data/embeddings/shard_{0000..0099}.tar",
+        "captions": "/data/captions/shard_{0000..0099}.tar",
+    },
+    shardshuffle=100,
+).decode("rgb")
+
+for sample in ds:
+    image = sample["jpg"]         # decoded numpy array
+    embedding = sample["emb.npy"] # decoded numpy array
+    caption = sample["txt"]       # decoded string
+```
+
+## Metadata Fields
+
+Each merged sample contains:
+
+| Key | Description |
+|-----|-------------|
+| `__key__` | Sample key (shared across modalities) |
+| `__url__` | Space-separated URLs of all source tar files |
+| `__url_<name>__` | URL of the tar file for a specific modality |
+
+```python
+for sample in ds:
+    print(sample["__key__"])              # "photo_00000_00000042"
+    print(sample["__url_images__"])       # "/data/images/shard_0000.tar"
+    print(sample["__url_embeddings__"])   # "/data/embeddings/shard_0000.tar"
+```
+
+## Extension Key Collisions
+
+If two modalities produce the same extension key (e.g., both have `.txt` files),
+a `ValueError` is raised. To avoid this, use distinct file extensions in each
+modality's tar files, or use `rename_files` to disambiguate:
+
+```python
+ds = wds.MultiModalWebDataset(
+    modalities={
+        "captions_en": "/data/en/shard_{0000..0099}.tar",    # contains .txt
+        "captions_fr": "/data/fr/shard_{0000..0099}.tar",    # also contains .txt -- collision!
+    },
+    shardshuffle=False,
+)
+# Raises: ValueError: extension key 'txt' from modality 'captions_fr' collides...
+```
+
+## Distributed Training
+
+`MultiModalWebDataset` supports multi-node and multi-worker training out of the
+box, using the same `nodesplitter` and `workersplitter` functions as `WebDataset`.
+Since shards are paired before splitting, each worker/node receives complete
+shard pairs:
+
+```python
+ds = wds.MultiModalWebDataset(
+    modalities={...},
+    shardshuffle=100,
+    detshuffle=True,
+    seed=42,
+    nodesplitter=wds.split_by_node,    # split shards across DDP ranks
+    workersplitter=wds.split_by_worker, # split shards across DataLoader workers
+)
+
+loader = DataLoader(ds, num_workers=4, batch_size=None)
+```
+
+## Streaming from Cloud Storage (Wasabi/S3/GCS)
+
+For S3-compatible storage (AWS, Wasabi, MinIO, etc.), use `pipe:` URLs:
+
+```python
+s3cmd = "AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... aws s3 cp --endpoint-url=https://s3.wasabisys.com"
+bucket = "s3://my-bucket/dataset"
+
+ds = wds.MultiModalWebDataset(
+    modalities={
+        "images": [f"pipe:{s3cmd} {bucket}/images/shard_{i:05d}.tar -" for i in range(100)],
+        "embeddings": [f"pipe:{s3cmd} {bucket}/embeddings/shard_{i:05d}.tar -" for i in range(100)],
+    },
+    shardshuffle=100,
+)
+```
+
+For GCS, use `gs://` URLs directly (requires `gsutil`):
+
+```python
+ds = wds.MultiModalWebDataset(
+    modalities={
+        "images": "gs://my-bucket/images/shard_{0000..0099}.tar",
+        "embeddings": "gs://my-bucket/embeddings/shard_{0000..0099}.tar",
+    },
+    shardshuffle=100,
+)
+```
+
+## Comparison with Column Store Approach
+
+The older [column store approach](column-store.md) uses `__url__` rewriting to
+load additional columns on the fly. `MultiModalWebDataset` improves on this:
+
+| Feature | Column Store | MultiModalWebDataset |
+|---------|-------------|---------------------|
+| Shard alignment | Manual (must ensure matching order) | Automatic (paired by index) |
+| Shuffling safety | Fragile (breaks if shards reordered) | Safe (pairs travel together) |
+| Worker splitting | Must match exactly | Handled automatically |
+| Missing samples | Crashes on `next()` | Configurable policy |
+| API | Custom `compose()` stage | Drop-in class with fluent interface |
+
+## Lower-Level Components
+
+For advanced use cases, the building blocks are available separately:
+
+### `PairedShardList`
+
+Iterable dataset that yields paired URL dicts:
+
+```python
+psl = wds.PairedShardList(
+    modalities={
+        "images": "/data/images/shard_{0000..0099}.tar",
+        "embeddings": "/data/embeddings/shard_{0000..0099}.tar",
+    },
+    seed=42,  # optional shuffling
+)
+
+for shard_group in psl:
+    print(shard_group)
+    # {"urls": {"images": "/data/images/shard_0042.tar", "embeddings": "/data/embeddings/shard_0042.tar"}}
+```
+
+### `PairedTarExpander`
+
+Pipeline filter that opens paired tars and merges samples:
+
+```python
+ds = wds.DataPipeline(
+    wds.PairedShardList(modalities={...}),
+    wds.split_by_worker,
+    wds.PairedTarExpander(handler=wds.warn_and_continue, missing_key_policy="skip"),
+)
+```
+
+## Full Example
+
+```python
+import webdataset as wds
+from torch.utils.data import DataLoader
+
+# Define modalities
+modalities = {
+    "images": "/data/images/shard_{0000..0113}.tar",
+    "embeddings": "/data/embeddings/shard_{0000..0113}.tar",
+}
+
+# Create dataset with full pipeline
+train_ds = (
+    wds.MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=100,
+        detshuffle=True,
+        seed=42,
+        handler=wds.warn_and_continue,
+    )
+    .decode("rgb")
+    .to_tuple("jpg", "emb.npy")
+    .shuffle(1000)
+    .batched(32, collation_fn=None)  # None for variable-size images
+)
+
+# Use with DataLoader
+loader = DataLoader(train_ds, num_workers=4, batch_size=None)
+
+for batch in loader:
+    images, embeddings = zip(*batch)
+    # Process batch...
+    break
+```

--- a/src/webdataset/__init__.py
+++ b/src/webdataset/__init__.py
@@ -57,6 +57,7 @@ from .handlers import (
     warn_and_stop,
 )
 from .mix import RandomMix, RoundRobin
+from .multimodal import MultiModalWebDataset, PairedShardList, PairedTarExpander
 from .pipeline import DataPipeline
 from .shardlists import (
     MultiShardSample,

--- a/src/webdataset/multimodal.py
+++ b/src/webdataset/multimodal.py
@@ -1,0 +1,452 @@
+"""Multi-modal WebDataset loading from separate tar files.
+
+This module provides support for loading datasets where different modalities
+(e.g., images, embeddings, text) are stored in separate tar file directories
+with matching shard structures.
+"""
+
+import os
+import random
+import warnings
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Union
+
+from . import filters, shardlists
+from .compat import FluidInterface, check_empty
+from .filters import pipelinefilter, reraise_exception
+from .pipeline import DataPipeline
+from .pytorch import IterableDataset
+from .tariterators import group_by_keys, tar_file_iterator
+
+
+class PairedShardList(IterableDataset):
+    """An iterable dataset that yields paired shard URLs across modalities.
+
+    Takes a dict mapping modality names to shard URL patterns, expands URLs,
+    validates all modalities have the same shard count, and yields paired
+    URL dictionaries.
+
+    Args:
+        modalities: Dict mapping modality names to shard URL patterns
+            (strings with brace expansion or lists of URLs).
+        seed: Random seed for shuffling; if None, no shuffling is done.
+    """
+
+    def __init__(self, modalities: Dict[str, Union[str, List[str]]], seed: Optional[int] = None):
+        super().__init__()
+        self.seed = seed
+
+        # Expand URLs for each modality
+        self.modality_urls: Dict[str, List[str]] = {}
+        for name, urls in modalities.items():
+            if isinstance(urls, str):
+                expanded = shardlists.expand_urls(urls)
+            else:
+                expanded = list(urls)
+            if len(expanded) == 0:
+                raise ValueError(f"modality {name!r} has no shard URLs")
+            self.modality_urls[name] = expanded
+
+        # Validate all modalities have the same shard count
+        counts = {name: len(urls) for name, urls in self.modality_urls.items()}
+        unique_counts = set(counts.values())
+        if len(unique_counts) > 1:
+            raise ValueError(
+                f"all modalities must have the same number of shards, got: "
+                + ", ".join(f"{name}={count}" for name, count in counts.items())
+            )
+
+        self.nshards = next(iter(counts.values()))
+        self.modality_names = list(self.modality_urls.keys())
+
+    def __len__(self) -> int:
+        return self.nshards
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        indices = list(range(self.nshards))
+        if self.seed is not None:
+            random.Random(self.seed).shuffle(indices)
+        for idx in indices:
+            urls = {name: self.modality_urls[name][idx] for name in self.modality_names}
+            yield dict(urls=urls)
+
+
+def _iter_tar_samples(
+    url: str,
+    handler: Callable = reraise_exception,
+    select_files: Optional[Callable] = None,
+    rename_files: Optional[Callable] = None,
+) -> Iterator[Dict[str, Any]]:
+    """Open a tar URL and yield grouped samples (key -> {suffix: data}).
+
+    This is a helper that chains URL opening, tar iteration, and grouping
+    for a single tar file.
+
+    Args:
+        url: URL of the tar file to open.
+        handler: Exception handler.
+        select_files: Predicate for selecting files.
+        rename_files: Function to rename files.
+
+    Yields:
+        Grouped sample dicts with __key__ and extension keys.
+    """
+    from urllib.parse import urlparse
+
+    from .gopen import gopen as _gopen
+
+    parsed = urlparse(url)
+    stream: Any = None
+    try:
+        if parsed.scheme in ["", "file"]:
+            stream = open(parsed.path, "rb")
+        else:
+            stream = _gopen(url)
+    except Exception as exn:
+        exn.args = exn.args + (url,)
+        if handler(exn):
+            return
+        else:
+            return
+
+    try:
+        for tarinfo_sample in tar_file_iterator(
+            stream,
+            handler=handler,
+            select_files=select_files,
+            rename_files=rename_files,
+        ):
+            tarinfo_sample["__url__"] = url
+            yield tarinfo_sample
+    finally:
+        if hasattr(stream, "close"):
+            stream.close()
+
+
+def _group_tar_samples(
+    file_iter: Iterator[Dict[str, Any]],
+    handler: Callable = reraise_exception,
+) -> Iterator[Dict[str, Any]]:
+    """Group raw file entries into samples by key.
+
+    Args:
+        file_iter: Iterator of dict(fname=..., data=..., __url__=...).
+        handler: Exception handler.
+
+    Yields:
+        Grouped sample dicts with __key__, __url__, and extension keys.
+    """
+    yield from group_by_keys(file_iter, handler=handler)
+
+
+def paired_tar_expander(
+    data: Iterator[Dict[str, Any]],
+    handler: Callable = reraise_exception,
+    select_files: Optional[Callable] = None,
+    rename_files: Optional[Callable] = None,
+    missing_key_policy: str = "skip",
+) -> Iterator[Dict[str, Any]]:
+    """Expand paired shard URLs into merged multi-modal samples.
+
+    For each shard group (dict with urls={name: url, ...}), opens all tar files
+    simultaneously, groups files into samples by key within each modality, then
+    merges samples across modalities by matching __key__ values.
+
+    Uses a streaming sorted merge: maintains one buffered sample per modality.
+    When all keys match, merges and yields. When keys differ, advances the
+    modality with the minimum key.
+
+    Args:
+        data: Iterator of dict(urls={name: url, ...}).
+        handler: Exception handler.
+        select_files: Predicate for selecting files from tar archives.
+        rename_files: Function to rename files from tar archives.
+        missing_key_policy: How to handle samples missing from some modalities.
+            "skip" (default): Drop samples not present in all modalities.
+            "partial": Yield samples with whatever modalities are available.
+            "error": Raise ValueError if a key is missing from any modality.
+
+    Yields:
+        Merged sample dicts with __key__ and keys from all modalities.
+
+    Raises:
+        ValueError: If missing_key_policy is "error" and keys don't align,
+            or if two modalities produce the same extension key.
+    """
+    if missing_key_policy not in ("skip", "partial", "error"):
+        raise ValueError(f"missing_key_policy must be 'skip', 'partial', or 'error', got {missing_key_policy!r}")
+
+    for shard_group in data:
+        try:
+            assert isinstance(shard_group, dict) and "urls" in shard_group
+            urls = shard_group["urls"]
+            modality_names = list(urls.keys())
+
+            # Create grouped sample iterators for each modality
+            iters = {}
+            for name in modality_names:
+                file_stream = _iter_tar_samples(
+                    urls[name],
+                    handler=handler,
+                    select_files=select_files,
+                    rename_files=rename_files,
+                )
+                iters[name] = _group_tar_samples(file_stream, handler=handler)
+
+            # Buffer one sample per modality
+            buffers: Dict[str, Optional[Dict[str, Any]]] = {}
+            exhausted: Set[str] = set()
+
+            def advance(name: str) -> None:
+                try:
+                    buffers[name] = next(iters[name])
+                except StopIteration:
+                    buffers[name] = None
+                    exhausted.add(name)
+
+            # Initial fill
+            for name in modality_names:
+                advance(name)
+
+            while len(exhausted) < len(modality_names):
+                # Get current keys from non-exhausted modalities
+                active_keys = {}
+                for name in modality_names:
+                    buf = buffers[name]
+                    if name not in exhausted and buf is not None:
+                        active_keys[name] = buf["__key__"]
+
+                if not active_keys:
+                    break
+
+                min_key = min(active_keys.values())
+                max_key = max(active_keys.values())
+
+                if min_key == max_key:
+                    # All active modalities have the same key - merge
+                    merged = _merge_samples(buffers, modality_names, exhausted, missing_key_policy)
+                    if merged is not None:
+                        yield merged
+                    # Advance all active modalities
+                    for name in modality_names:
+                        if name not in exhausted:
+                            advance(name)
+                else:
+                    # Keys differ - handle based on policy
+                    names_with_min = [n for n, k in active_keys.items() if k == min_key]
+
+                    if missing_key_policy == "error":
+                        raise ValueError(
+                            f"key mismatch across modalities: "
+                            + ", ".join(f"{n}={active_keys[n]!r}" for n in modality_names if n in active_keys)
+                        )
+                    elif missing_key_policy == "partial":
+                        # Yield partial sample with the min key
+                        partial = {"__key__": min_key}
+                        for name in names_with_min:
+                            sample = buffers[name]
+                            assert sample is not None
+                            _add_modality_to_sample(partial, name, sample)
+                        yield partial
+                        for name in names_with_min:
+                            advance(name)
+                    else:
+                        # skip: advance the modality(ies) with the minimum key
+                        for name in names_with_min:
+                            advance(name)
+
+            # Handle remaining buffered samples for partial policy
+            if missing_key_policy == "partial":
+                for name in modality_names:
+                    buf = buffers[name]
+                    if name not in exhausted and buf is not None:
+                        partial = {"__key__": buf["__key__"]}
+                        _add_modality_to_sample(partial, name, buf)
+                        yield partial
+                        # Drain remaining
+                        for remaining in iters[name]:
+                            partial = {"__key__": remaining["__key__"]}
+                            _add_modality_to_sample(partial, name, remaining)
+                            yield partial
+
+        except Exception as exn:
+            if handler(exn):
+                continue
+            else:
+                break
+
+
+def _add_modality_to_sample(
+    merged: Dict[str, Any],
+    modality_name: str,
+    sample: Dict[str, Any],
+) -> None:
+    """Add keys from a modality sample to the merged sample dict.
+
+    Args:
+        merged: The merged sample dict to update.
+        modality_name: Name of the modality being added.
+        sample: The modality sample dict.
+
+    Raises:
+        ValueError: If an extension key collides with an existing key.
+    """
+    url = sample.get("__url__", "")
+    merged[f"__url_{modality_name}__"] = url
+    if "__url__" not in merged:
+        merged["__url__"] = url
+    else:
+        merged["__url__"] = merged["__url__"] + " " + url
+
+    for key, value in sample.items():
+        if key.startswith("__") and key.endswith("__"):
+            continue
+        if key in merged:
+            raise ValueError(
+                f"extension key {key!r} from modality {modality_name!r} "
+                f"collides with an existing key in the merged sample"
+            )
+        merged[key] = value
+
+
+def _merge_samples(
+    buffers: Dict[str, Optional[Dict[str, Any]]],
+    modality_names: List[str],
+    exhausted: Set[str],
+    missing_key_policy: str,
+) -> Optional[Dict[str, Any]]:
+    """Merge buffered samples from all modalities into a single sample.
+
+    Args:
+        buffers: Dict mapping modality name to current buffered sample.
+        modality_names: List of all modality names.
+        exhausted: Set of exhausted modality names.
+        missing_key_policy: Policy for handling missing keys.
+
+    Returns:
+        Merged sample dict, or None if the sample should be skipped.
+    """
+    # Get the key from any active modality
+    key = None
+    for name in modality_names:
+        buf = buffers[name]
+        if name not in exhausted and buf is not None:
+            key = buf["__key__"]
+            break
+    if key is None:
+        return None
+
+    # Check if any modality is missing this key
+    missing = [name for name in modality_names if name in exhausted or buffers[name] is None]
+    if missing:
+        if missing_key_policy == "error":
+            raise ValueError(f"key {key!r} missing from modalities: {missing}")
+        elif missing_key_policy == "skip":
+            return None
+
+    merged: Dict[str, Any] = {"__key__": key}
+    for name in modality_names:
+        buf = buffers[name]
+        if name not in exhausted and buf is not None:
+            _add_modality_to_sample(merged, name, buf)
+
+    return merged
+
+
+class MultiModalWebDataset(DataPipeline, FluidInterface):
+    """WebDataset pipeline for loading data from separate tar files per modality.
+
+    Each modality is stored in its own set of tar shards with matching shard
+    structure. Shards are paired across modalities before splitting/shuffling,
+    ensuring alignment is maintained.
+
+    Args:
+        modalities: Dict mapping modality names to shard URL patterns.
+        handler: Function to handle exceptions. Defaults to reraise_exception.
+        shardshuffle: Number of shards to shuffle, or None/False.
+        detshuffle: Whether to use deterministic shuffling.
+        nodesplitter: Function to split data by node.
+        workersplitter: Function to split data by worker.
+        select_files: Function to select files from tar archives.
+        rename_files: Function to rename files from tar archives.
+        empty_check: Whether to check for empty datasets.
+        seed: Random seed for shuffling.
+        missing_key_policy: How to handle samples missing from some modalities.
+            "skip" (default), "partial", or "error".
+
+    Example::
+
+        ds = wds.MultiModalWebDataset(
+            modalities={
+                "images": "s3://bucket/images/shard_{0000..0099}.tar",
+                "embeddings": "s3://bucket/embeddings/shard_{0000..0099}.tar",
+            },
+            shardshuffle=100,
+        ).decode("pil").to_tuple("jpg", "npy").batched(32)
+    """
+
+    def __init__(
+        self,
+        modalities: Dict[str, Union[str, List[str]]],
+        handler: Callable = reraise_exception,
+        shardshuffle: Optional[Union[int, bool]] = None,
+        detshuffle: bool = False,
+        nodesplitter: Optional[Callable] = shardlists.single_node_only,
+        workersplitter: Optional[Callable] = shardlists.split_by_worker,
+        select_files: Optional[Callable] = None,
+        rename_files: Optional[Callable] = None,
+        empty_check: bool = True,
+        seed: Optional[int] = None,
+        missing_key_policy: str = "skip",
+    ):
+        super().__init__()
+
+        if shardshuffle is None:
+            warnings.warn("MultiModalWebDataset(shardshuffle=...) is None; set explicitly to False or a number")
+        if shardshuffle is True:
+            warnings.warn("set MultiModalWebDataset(shardshuffle=...) to a positive integer or 0 or False")
+            shardshuffle = 100
+
+        self.seed = int(os.environ.get("WDS_SEED", random.randint(0, 1000000))) if seed is None else seed
+
+        # 1. Paired shard URL generation
+        self.append(PairedShardList(modalities))
+
+        # 2. Node splitting (for distributed processing)
+        if nodesplitter is not None:
+            self.append(nodesplitter)
+
+        # 3. Worker splitting (for DataLoader)
+        if workersplitter is not None:
+            self.append(workersplitter)
+
+        # 4. Shard shuffling
+        if shardshuffle is not None and shardshuffle is not False:
+            if detshuffle:
+                self.append(filters.detshuffle(shardshuffle, seed=self.seed))
+            else:
+                self.append(filters.shuffle(shardshuffle, seed=self.seed))
+
+        # 5. Open paired tars and merge samples
+        expander = pipelinefilter(paired_tar_expander)
+        self.append(
+            expander(
+                handler=handler,
+                select_files=select_files,
+                rename_files=rename_files,
+                missing_key_policy=missing_key_policy,
+            )
+        )
+
+        # 6. Check for empty datasets
+        if empty_check:
+            self.append(check_empty)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+# Alias for export compatibility
+PairedTarExpander = pipelinefilter(paired_tar_expander)

--- a/src/webdataset/typecheck.py
+++ b/src/webdataset/typecheck.py
@@ -9,6 +9,7 @@ modules = [
     "gopen",
     "handlers",
     "mix",
+    "multimodal",
     "pipeline",
     "shardlists",
     "tariterators",

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -1,0 +1,529 @@
+"""Tests for multi-modal WebDataset loading from separate tar files."""
+
+import os
+
+import numpy as np
+import pytest
+
+import webdataset as wds
+from webdataset import writer
+from webdataset.multimodal import MultiModalWebDataset, PairedShardList, paired_tar_expander
+
+
+def _create_tar(path, samples):
+    """Create a tar file with the given samples.
+
+    Args:
+        path: Path to the tar file.
+        samples: List of dicts with __key__ and extension keys.
+    """
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with writer.TarWriter(path) as sink:
+        for sample in samples:
+            sink.write(sample)
+
+
+def _create_paired_shards(tmpdir, n_shards=2, n_samples_per_shard=3):
+    """Create paired image and embedding shards for testing.
+
+    Returns:
+        Tuple of (modalities dict, expected keys list).
+    """
+    all_keys = []
+    for shard_idx in range(n_shards):
+        image_samples = []
+        embedding_samples = []
+        for sample_idx in range(n_samples_per_shard):
+            key = f"sample_{shard_idx:04d}_{sample_idx:04d}"
+            all_keys.append(key)
+            image_samples.append(
+                {
+                    "__key__": key,
+                    "jpg": np.zeros((4, 4, 3), dtype=np.uint8),
+                }
+            )
+            embedding_samples.append(
+                {
+                    "__key__": key,
+                    "npy": np.ones((8,), dtype=np.float32),
+                }
+            )
+        _create_tar(f"{tmpdir}/images/shard_{shard_idx:04d}.tar", image_samples)
+        _create_tar(f"{tmpdir}/embeddings/shard_{shard_idx:04d}.tar", embedding_samples)
+
+    modalities = {
+        "images": f"{tmpdir}/images/shard_{{0000..{n_shards - 1:04d}}}.tar",
+        "embeddings": f"{tmpdir}/embeddings/shard_{{0000..{n_shards - 1:04d}}}.tar",
+    }
+    return modalities, sorted(all_keys)
+
+
+@pytest.mark.quick
+def test_paired_shard_list_basic(tmp_path):
+    """Test PairedShardList yields correct paired URL dicts."""
+    modalities = {
+        "images": ["/data/images/shard_0000.tar", "/data/images/shard_0001.tar"],
+        "embeddings": ["/data/embeddings/shard_0000.tar", "/data/embeddings/shard_0001.tar"],
+    }
+    psl = PairedShardList(modalities)
+    results = list(psl)
+    assert len(results) == 2
+    for r in results:
+        assert "urls" in r
+        assert "images" in r["urls"]
+        assert "embeddings" in r["urls"]
+
+    # Verify pairing by index
+    assert results[0]["urls"]["images"] == "/data/images/shard_0000.tar"
+    assert results[0]["urls"]["embeddings"] == "/data/embeddings/shard_0000.tar"
+    assert results[1]["urls"]["images"] == "/data/images/shard_0001.tar"
+    assert results[1]["urls"]["embeddings"] == "/data/embeddings/shard_0001.tar"
+
+
+@pytest.mark.quick
+def test_paired_shard_list_brace_expansion(tmp_path):
+    """Test PairedShardList with brace expansion strings."""
+    modalities = {
+        "a": "/data/a/shard_{0000..0003}.tar",
+        "b": "/data/b/shard_{0000..0003}.tar",
+    }
+    psl = PairedShardList(modalities)
+    assert len(psl) == 4
+    results = list(psl)
+    assert len(results) == 4
+
+
+@pytest.mark.quick
+def test_paired_shard_list_count_mismatch():
+    """Test that PairedShardList raises ValueError on shard count mismatch."""
+    modalities = {
+        "images": ["/data/images/shard_0000.tar", "/data/images/shard_0001.tar"],
+        "embeddings": ["/data/embeddings/shard_0000.tar"],
+    }
+    with pytest.raises(ValueError, match="same number of shards"):
+        PairedShardList(modalities)
+
+
+@pytest.mark.quick
+def test_paired_shard_list_shuffle(tmp_path):
+    """Test PairedShardList shuffling preserves pairing."""
+    modalities = {
+        "images": [f"/data/images/shard_{i:04d}.tar" for i in range(10)],
+        "embeddings": [f"/data/embeddings/shard_{i:04d}.tar" for i in range(10)],
+    }
+    psl = PairedShardList(modalities, seed=42)
+    results = list(psl)
+    assert len(results) == 10
+
+    # Verify pairing: shard index should match between modalities
+    for r in results:
+        img_url = r["urls"]["images"]
+        emb_url = r["urls"]["embeddings"]
+        img_idx = img_url.split("shard_")[1].split(".")[0]
+        emb_idx = emb_url.split("shard_")[1].split(".")[0]
+        assert img_idx == emb_idx, f"Pairing broken: {img_url} vs {emb_url}"
+
+    # Verify shuffling actually happened (with 10 items, seed 42 should change order)
+    unshuffled = PairedShardList(modalities)
+    unshuffled_results = list(unshuffled)
+    assert results != unshuffled_results, "Shuffling didn't change the order"
+
+
+@pytest.mark.quick
+def test_basic_iteration(tmp_path):
+    """Test basic multi-modal iteration merges samples correctly."""
+    modalities, expected_keys = _create_paired_shards(tmp_path)
+
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+    )
+
+    collected_keys = []
+    for sample in ds:
+        assert "__key__" in sample
+        assert "jpg" in sample
+        assert "npy" in sample
+        assert "__url_images__" in sample
+        assert "__url_embeddings__" in sample
+        collected_keys.append(sample["__key__"])
+
+    assert sorted(collected_keys) == expected_keys
+
+
+@pytest.mark.quick
+def test_missing_key_skip(tmp_path):
+    """Test missing_key_policy='skip' drops misaligned samples."""
+    # Create image shard with keys a, b, c
+    _create_tar(
+        f"{tmp_path}/images/shard_0000.tar",
+        [
+            {"__key__": "a", "jpg": np.zeros((2, 2, 3), dtype=np.uint8)},
+            {"__key__": "b", "jpg": np.zeros((2, 2, 3), dtype=np.uint8)},
+            {"__key__": "c", "jpg": np.zeros((2, 2, 3), dtype=np.uint8)},
+        ],
+    )
+    # Create embedding shard with keys a, c (missing b)
+    _create_tar(
+        f"{tmp_path}/embeddings/shard_0000.tar",
+        [
+            {"__key__": "a", "npy": np.ones((4,), dtype=np.float32)},
+            {"__key__": "c", "npy": np.ones((4,), dtype=np.float32)},
+        ],
+    )
+
+    modalities = {
+        "images": [f"{tmp_path}/images/shard_0000.tar"],
+        "embeddings": [f"{tmp_path}/embeddings/shard_0000.tar"],
+    }
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+        missing_key_policy="skip",
+    )
+
+    results = list(ds)
+    keys = [r["__key__"] for r in results]
+    assert keys == ["a", "c"], f"Expected ['a', 'c'], got {keys}"
+
+
+@pytest.mark.quick
+def test_missing_key_error(tmp_path):
+    """Test missing_key_policy='error' raises on misaligned samples."""
+    _create_tar(
+        f"{tmp_path}/images/shard_0000.tar",
+        [
+            {"__key__": "a", "jpg": np.zeros((2, 2, 3), dtype=np.uint8)},
+            {"__key__": "b", "jpg": np.zeros((2, 2, 3), dtype=np.uint8)},
+        ],
+    )
+    _create_tar(
+        f"{tmp_path}/embeddings/shard_0000.tar",
+        [
+            {"__key__": "a", "npy": np.ones((4,), dtype=np.float32)},
+            {"__key__": "c", "npy": np.ones((4,), dtype=np.float32)},
+        ],
+    )
+
+    modalities = {
+        "images": [f"{tmp_path}/images/shard_0000.tar"],
+        "embeddings": [f"{tmp_path}/embeddings/shard_0000.tar"],
+    }
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+        missing_key_policy="error",
+    )
+
+    with pytest.raises(ValueError, match="key mismatch"):
+        list(ds)
+
+
+@pytest.mark.quick
+def test_missing_key_partial(tmp_path):
+    """Test missing_key_policy='partial' yields partial samples."""
+    _create_tar(
+        f"{tmp_path}/images/shard_0000.tar",
+        [
+            {"__key__": "a", "jpg": np.zeros((2, 2, 3), dtype=np.uint8)},
+            {"__key__": "b", "jpg": np.zeros((2, 2, 3), dtype=np.uint8)},
+            {"__key__": "c", "jpg": np.zeros((2, 2, 3), dtype=np.uint8)},
+        ],
+    )
+    _create_tar(
+        f"{tmp_path}/embeddings/shard_0000.tar",
+        [
+            {"__key__": "a", "npy": np.ones((4,), dtype=np.float32)},
+            {"__key__": "c", "npy": np.ones((4,), dtype=np.float32)},
+        ],
+    )
+
+    modalities = {
+        "images": [f"{tmp_path}/images/shard_0000.tar"],
+        "embeddings": [f"{tmp_path}/embeddings/shard_0000.tar"],
+    }
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+        missing_key_policy="partial",
+    )
+
+    results = list(ds)
+    keys = [r["__key__"] for r in results]
+    assert "a" in keys
+    assert "b" in keys
+    assert "c" in keys
+
+    # 'a' and 'c' should have both modalities
+    a_sample = [r for r in results if r["__key__"] == "a"][0]
+    assert "jpg" in a_sample
+    assert "npy" in a_sample
+
+    # 'b' should only have images
+    b_sample = [r for r in results if r["__key__"] == "b"][0]
+    assert "jpg" in b_sample
+    assert "npy" not in b_sample
+
+
+@pytest.mark.quick
+def test_shard_shuffling(tmp_path):
+    """Test that shard shuffling produces same total samples."""
+    modalities, expected_keys = _create_paired_shards(tmp_path, n_shards=3, n_samples_per_shard=2)
+
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=10,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+    )
+
+    collected_keys = []
+    for sample in ds:
+        collected_keys.append(sample["__key__"])
+
+    assert sorted(collected_keys) == expected_keys
+
+
+@pytest.mark.quick
+def test_three_modalities(tmp_path):
+    """Test with three modalities."""
+    for shard_idx in range(2):
+        samples_img = []
+        samples_emb = []
+        samples_txt = []
+        for sample_idx in range(3):
+            key = f"s_{shard_idx}_{sample_idx}"
+            samples_img.append({"__key__": key, "jpg": np.zeros((2, 2, 3), dtype=np.uint8)})
+            samples_emb.append({"__key__": key, "npy": np.ones((4,), dtype=np.float32)})
+            samples_txt.append({"__key__": key, "txt": f"caption {key}"})
+        _create_tar(f"{tmp_path}/images/shard_{shard_idx:04d}.tar", samples_img)
+        _create_tar(f"{tmp_path}/embeddings/shard_{shard_idx:04d}.tar", samples_emb)
+        _create_tar(f"{tmp_path}/text/shard_{shard_idx:04d}.tar", samples_txt)
+
+    modalities = {
+        "images": [f"{tmp_path}/images/shard_{i:04d}.tar" for i in range(2)],
+        "embeddings": [f"{tmp_path}/embeddings/shard_{i:04d}.tar" for i in range(2)],
+        "text": [f"{tmp_path}/text/shard_{i:04d}.tar" for i in range(2)],
+    }
+
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+    )
+
+    results = list(ds)
+    assert len(results) == 6
+    for sample in results:
+        assert "jpg" in sample
+        assert "npy" in sample
+        assert "txt" in sample
+        assert "__url_images__" in sample
+        assert "__url_embeddings__" in sample
+        assert "__url_text__" in sample
+
+
+@pytest.mark.quick
+def test_extension_collision(tmp_path):
+    """Test that duplicate extension keys across modalities raise ValueError."""
+    _create_tar(
+        f"{tmp_path}/mod_a/shard_0000.tar",
+        [
+            {"__key__": "a", "txt": "hello from mod_a"},
+        ],
+    )
+    _create_tar(
+        f"{tmp_path}/mod_b/shard_0000.tar",
+        [
+            {"__key__": "a", "txt": "hello from mod_b"},
+        ],
+    )
+
+    modalities = {
+        "mod_a": [f"{tmp_path}/mod_a/shard_0000.tar"],
+        "mod_b": [f"{tmp_path}/mod_b/shard_0000.tar"],
+    }
+
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+    )
+
+    with pytest.raises(ValueError, match="collides"):
+        list(ds)
+
+
+@pytest.mark.quick
+def test_fluid_interface_decode(tmp_path):
+    """Test FluidInterface chaining with decode."""
+    modalities, _ = _create_paired_shards(tmp_path, n_shards=1, n_samples_per_shard=2)
+
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+    ).decode("rgb")
+
+    for sample in ds:
+        assert isinstance(sample["jpg"], np.ndarray)
+        assert isinstance(sample["npy"], np.ndarray)
+        break
+
+
+@pytest.mark.quick
+def test_fluid_interface_to_tuple(tmp_path):
+    """Test FluidInterface chaining with to_tuple."""
+    modalities, _ = _create_paired_shards(tmp_path, n_shards=1, n_samples_per_shard=2)
+
+    ds = (
+        MultiModalWebDataset(
+            modalities=modalities,
+            shardshuffle=False,
+            nodesplitter=None,
+            workersplitter=None,
+            empty_check=False,
+        )
+        .decode("rgb")
+        .to_tuple("jpg", "npy")
+    )
+
+    for img, emb in ds:
+        assert isinstance(img, np.ndarray)
+        assert isinstance(emb, np.ndarray)
+        break
+
+
+@pytest.mark.quick
+def test_fluid_interface_batched(tmp_path):
+    """Test FluidInterface chaining with batched."""
+    modalities, _ = _create_paired_shards(tmp_path, n_shards=1, n_samples_per_shard=4)
+
+    ds = (
+        MultiModalWebDataset(
+            modalities=modalities,
+            shardshuffle=False,
+            nodesplitter=None,
+            workersplitter=None,
+            empty_check=False,
+        )
+        .decode("rgb")
+        .to_tuple("jpg", "npy")
+        .batched(2)
+    )
+
+    count = 0
+    for batch in ds:
+        imgs, embs = batch
+        assert len(imgs) == 2
+        assert len(embs) == 2
+        count += 1
+    assert count == 2
+
+
+@pytest.mark.quick
+def test_with_epoch(tmp_path):
+    """Test with_epoch works."""
+    modalities, _ = _create_paired_shards(tmp_path, n_shards=1, n_samples_per_shard=5)
+
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+    ).with_epoch(3)
+
+    count = sum(1 for _ in ds)
+    assert count == 3
+
+
+@pytest.mark.quick
+def test_repeat(tmp_path):
+    """Test repeat works."""
+    modalities, _ = _create_paired_shards(tmp_path, n_shards=1, n_samples_per_shard=2)
+
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+    ).repeat(3)
+
+    count = sum(1 for _ in ds)
+    assert count == 6  # 2 samples * 3 repeats
+
+
+@pytest.mark.quick
+def test_empty_modality_urls():
+    """Test that empty URL list raises ValueError."""
+    with pytest.raises(ValueError, match="no shard URLs"):
+        PairedShardList({"images": []})
+
+
+@pytest.mark.quick
+def test_paired_shard_list_len():
+    """Test __len__ of PairedShardList."""
+    psl = PairedShardList(
+        {
+            "a": ["/shard_0.tar", "/shard_1.tar", "/shard_2.tar"],
+            "b": ["/shard_0.tar", "/shard_1.tar", "/shard_2.tar"],
+        }
+    )
+    assert len(psl) == 3
+
+
+@pytest.mark.quick
+def test_exports():
+    """Test that multimodal classes are exported from webdataset package."""
+    assert hasattr(wds, "MultiModalWebDataset")
+    assert hasattr(wds, "PairedShardList")
+    assert hasattr(wds, "PairedTarExpander")
+
+
+@pytest.mark.quick
+def test_perfectly_aligned_shards(tmp_path):
+    """Test that perfectly aligned shards produce all samples."""
+    keys = [f"sample_{i:04d}" for i in range(10)]
+    img_samples = [{"__key__": k, "png": np.zeros((3, 3, 3), dtype=np.uint8)} for k in keys]
+    emb_samples = [{"__key__": k, "npy": np.ones((16,), dtype=np.float32)} for k in keys]
+
+    _create_tar(f"{tmp_path}/images/shard_0000.tar", img_samples)
+    _create_tar(f"{tmp_path}/embeddings/shard_0000.tar", emb_samples)
+
+    modalities = {
+        "images": [f"{tmp_path}/images/shard_0000.tar"],
+        "embeddings": [f"{tmp_path}/embeddings/shard_0000.tar"],
+    }
+    ds = MultiModalWebDataset(
+        modalities=modalities,
+        shardshuffle=False,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+    )
+
+    results = list(ds)
+    assert len(results) == 10
+    result_keys = sorted(r["__key__"] for r in results)
+    assert result_keys == sorted(keys)


### PR DESCRIPTION
## Summary

- Adds `MultiModalWebDataset` class for loading datasets where each modality (images, embeddings, text, etc.) is stored in separate tar file directories with matching shard structures
- Pairs shards across modalities before splitting/shuffling to guarantee alignment through the pipeline
- Includes streaming sorted merge by `__key__` with configurable `missing_key_policy` (`skip`, `partial`, `error`)

This addresses the gap noted in `docs/column-store.md`:

> *"This is quite easy in WebDataset, although there is no explicit API for it (one will likely be added)."*

## Motivation

Many real-world datasets (e.g., img2dataset outputs, LAION-style datasets) store modalities in separate tar directories:

```
images/shard_0000.tar         embeddings/shard_0000.tar
  sample_000.jpg                sample_000.emb.npy
  sample_001.jpg                sample_001.emb.npy
```

The existing column-store approach (`compose(add_column)`) is fragile — independent shuffling, worker splitting, or missing samples break alignment. `MultiModalWebDataset` solves this structurally by pairing shards before they enter the pipeline.

## Usage

```python
import webdataset as wds

ds = wds.MultiModalWebDataset(
    modalities={
        "images": "s3://bucket/images/shard_{0000..0099}.tar",
        "embeddings": "s3://bucket/embeddings/shard_{0000..0099}.tar",
    },
    shardshuffle=100,
    detshuffle=True,
    seed=42,
).decode("rgb").to_tuple("jpg", "emb.npy")

for image, embedding in DataLoader(ds, num_workers=4):
    ...
```

## Changes

- **New:** `src/webdataset/multimodal.py` — `PairedShardList`, `paired_tar_expander`, `MultiModalWebDataset`
- **New:** `tests/test_multimodal.py` — 20 tests covering alignment, missing keys, shuffling, 3+ modalities, FluidInterface chaining, extension collisions
- **New:** `docs/multimodal.md` — full usage documentation
- **Modified:** `src/webdataset/__init__.py` — added exports
- **Modified:** `src/webdataset/typecheck.py` — added module to typeguard list

## Design Decisions

- **Paired shards, not separate pipelines + zip** — separate pipelines would require identical shuffling seeds, identical splitting, and break on missing samples
- **Streaming sorted merge** — O(1) memory per modality, zero overhead when keys align perfectly
- **FluidInterface inheritance** — all chaining methods (`.decode()`, `.shuffle()`, `.to_tuple()`, `.batched()`, etc.) work
- **No `cache_dir` support yet** — the existing `FileCache` expects `dict(url=...)` items; per-modality caching can be added as a follow-up

## Test plan

- [x] `uv run pytest tests/test_multimodal.py -v` — 20/20 passing
- [x] `uv run pytest -v -m quick` — 30/30 passing (zero regressions)
- [x] `uv run mypy src/webdataset/multimodal.py` — no errors
- [x] `uv run ruff check src/webdataset/multimodal.py` — all checks passed
- [x] Tested on real dataset (114 shards, ~5K samples/shard, Wasabi S3)

## Open Questions

- Should this be a separate class or integrated into `WebDataset` via a `modalities=` parameter?
- Should `cache_dir` support be added before merging?
- Any preferences on naming (`MultiModalWebDataset` vs `PairedWebDataset` etc.)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)