### PR TITLE
Preserve shard-level randomness across dataset iterations

### DIFF
--- a/src/webdataset/compat.py
+++ b/src/webdataset/compat.py
@@ -381,7 +381,15 @@ class WebDataset(DataPipeline, FluidInterface):
             warnings.warn("set WebDataset(shardshuffle=...) to a positive integer or 0 or False")
             shardshuffle = 100
         args = SimpleNamespace(**locals())
-        self.seed = os.environ.get("WDS_SEED", random.randint(0, 1000000)) if seed is None else seed
+        self.seed = seed if seed is not None else os.environ.get("WDS_SEED")
+        # Ordinary shuffle interprets None as a fresh RNG per iteration; detshuffle needs a stable base.
+        if self.seed is None:
+            self._detshuffle_seed = random.randint(0, 1000000)
+        elif isinstance(self.seed, str):
+            # detshuffle adds the epoch numerically, so map environment strings to a stable integer.
+            self._detshuffle_seed = random.Random(self.seed).getrandbits(64)
+        else:
+            self._detshuffle_seed = self.seed
         self.update_cache_info(args)
 
         # first, we add a generator for the urls to used
@@ -399,7 +407,7 @@ class WebDataset(DataPipeline, FluidInterface):
         # add a shard shuffler
         if args.shardshuffle is not None:
             if args.detshuffle:
-                self.append(filters.detshuffle(args.shardshuffle, seed=self.seed))
+                self.append(filters.detshuffle(args.shardshuffle, seed=self._detshuffle_seed))
             else:
                 self.append(filters.shuffle(args.shardshuffle, seed=self.seed))
 

--- a/src/webdataset/compat.pyi
+++ b/src/webdataset/compat.pyi
@@ -53,7 +53,7 @@ class FluidInterface:
 def check_empty(source: Iterable[Sample]) -> Iterator[Sample]: ...
 
 class WebDataset(DataPipeline, FluidInterface):
-    seed: int
+    seed: Optional[Union[int, str]]
 
     def __init__(
         self,

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -15,7 +15,7 @@ from tests.conftest import (
     remote_shard,
     remote_shards,
 )
-from webdataset import compat
+from webdataset import compat, filters
 
 
 def identity(x):
@@ -565,15 +565,96 @@ def test_lmdb_cached(tmp_path):
     assert len(result1) == len(result3)
 
 
-def test_shuffle_seed():
-    """Test that shuffle is deterministic for a given seed."""
+def make_shard_shuffle_only_dataset(seed=0, detshuffle=False):
+    """Create a WebDataset pipeline truncated immediately after shard shuffling."""
+    dataset = compat.WebDataset(
+        "shard-{000000..000999}.tar",
+        shardshuffle=100,
+        seed=seed,
+        detshuffle=detshuffle,
+        nodesplitter=None,
+        workersplitter=None,
+        empty_check=False,
+    )
+    for index, stage in enumerate(dataset.pipeline):
+        ordinary_shuffle = isinstance(stage, filters.FilterFunction) and stage.f is filters._shuffle
+        if ordinary_shuffle or isinstance(stage, filters.detshuffle):
+            del dataset.pipeline[index + 1 :]
+            return dataset
+    raise AssertionError("shard shuffle stage not found")
 
-    def make_shuffle_only_ds(seed=0):
-        ds = compat.WebDataset("shard-{000000..000999}.tar", shardshuffle=True, seed=seed)
-        index = ["shuffle" in str(stage) for stage in ds.pipeline].index(True)
-        del ds.pipeline[index + 1 :]
-        return ds
 
-    ds1 = make_shuffle_only_ds(seed=0)
-    ds2 = make_shuffle_only_ds(seed=0)
-    assert list(ds1) == list(ds2)
+def shard_order(dataset):
+    """Return the URL order produced by a shard-only dataset."""
+    return [sample["url"] for sample in dataset]
+
+
+def test_shuffle_with_explicit_seed_is_repeatable(monkeypatch):
+    """An explicit seed produces the same ordinary shuffle on every iteration."""
+    monkeypatch.delenv("WDS_SEED", raising=False)
+    dataset1 = make_shard_shuffle_only_dataset(seed=0)
+    dataset2 = make_shard_shuffle_only_dataset(seed=0)
+
+    first_order = shard_order(dataset1)
+    assert first_order == shard_order(dataset2)
+    assert first_order == shard_order(dataset1)
+
+
+def test_shuffle_without_configured_seed_varies_by_iteration(monkeypatch):
+    """An unseeded ordinary shuffle creates a fresh order for each iteration."""
+    monkeypatch.delenv("WDS_SEED", raising=False)
+    dataset = make_shard_shuffle_only_dataset(seed=None)
+
+    first_order = shard_order(dataset)
+    second_order = shard_order(dataset)
+    assert dataset.seed is None
+    assert len(first_order) == 1000
+    assert set(first_order) == set(second_order)
+    assert first_order != second_order
+
+
+def test_wds_seed_is_repeatable_and_explicit_seed_takes_precedence(monkeypatch):
+    """WDS_SEED seeds ordinary shuffle unless an explicit seed is supplied."""
+    monkeypatch.delenv("WDS_SEED", raising=False)
+    expected_explicit_order = shard_order(make_shard_shuffle_only_dataset(seed=0))
+
+    monkeypatch.setenv("WDS_SEED", "fixed-seed")
+    environment_seeded = make_shard_shuffle_only_dataset(seed=None)
+    environment_order = shard_order(environment_seeded)
+    assert environment_seeded.seed == "fixed-seed"
+    assert environment_order == shard_order(environment_seeded)
+
+    explicitly_seeded = make_shard_shuffle_only_dataset(seed=0)
+    assert explicitly_seeded.seed == 0
+    assert shard_order(explicitly_seeded) == expected_explicit_order
+
+
+def test_detshuffle_is_epoch_aware_and_repeatable(monkeypatch):
+    """Equal detshuffle seeds reproduce each epoch while changing between epochs."""
+    monkeypatch.delenv("WDS_SEED", raising=False)
+    dataset1 = make_shard_shuffle_only_dataset(seed=123, detshuffle=True)
+    dataset2 = make_shard_shuffle_only_dataset(seed=123, detshuffle=True)
+
+    epoch0_order = shard_order(dataset1)
+    epoch1_order = shard_order(dataset1)
+    assert epoch0_order == shard_order(dataset2)
+    assert epoch1_order == shard_order(dataset2)
+    assert epoch0_order != epoch1_order
+
+    unseeded = make_shard_shuffle_only_dataset(seed=None, detshuffle=True)
+    assert unseeded.seed is None
+    assert shard_order(unseeded) != shard_order(unseeded)
+
+
+def test_wds_seed_supports_detshuffle(monkeypatch):
+    """WDS_SEED provides a repeatable epoch-aware detshuffle base seed."""
+    monkeypatch.setenv("WDS_SEED", "fixed-seed")
+    dataset1 = make_shard_shuffle_only_dataset(seed=None, detshuffle=True)
+    dataset2 = make_shard_shuffle_only_dataset(seed=None, detshuffle=True)
+
+    epoch0_order = shard_order(dataset1)
+    epoch1_order = shard_order(dataset1)
+    assert dataset1.seed == "fixed-seed"
+    assert epoch0_order == shard_order(dataset2)
+    assert epoch1_order == shard_order(dataset2)
+    assert epoch0_order != epoch1_order


### PR DESCRIPTION
## Summary

`WebDataset(..., shardshuffle=N)` currently repeats the same shard order every time the same dataset is iterated, even when the user did not configure a seed. The dataset still produces valid samples, so this is easy to miss during training.

This PR restores per-iteration shard reshuffling when neither `seed` nor `WDS_SEED` is configured. Explicitly seeded pipelines remain repeatable.

## Why this matters

A fixed shard schedule can reduce diversity across nearby batches, repeat the same distribution shifts at the same point in every pass, and bias sample exposure when training is capped by a fixed step budget. A bounded sample-shuffle buffer does not remove this effect when adjacent shards retain locality—for example by source, class, language, time, quality, or generation batch.

The impact is smaller for pre-randomized or homogeneous shards. This PR targets ordinary shard shuffle over finite, non-resampled datasets; `ResampledShards` is unchanged.

## Behavior and compatibility

| Configuration | Ordinary shard shuffle |
| --- | --- |
| No `seed` or `WDS_SEED` | New PID/time-seeded RNG on each iteration |
| Explicit `seed` | Repeatable order |
| `WDS_SEED` | Repeatable order |

Before #373, ordinary shard shuffle received the constructor argument directly, so the default `seed=None` path created a new RNG on each iteration. #373 switched it to the resolved `dataset.seed`, which made generated and environment seeds effective but also made the unseeded order fixed for the lifetime of a dataset instance.

Restoring the old unseeded behavior means `dataset.seed` is now `None` when no seed was configured. This intentionally changes the #372 pattern of copying an automatically generated seed from one unseeded dataset into another: those pipelines will now shuffle independently.

For reproducibility, or to synchronize pipelines with one fixed order, callers should generate a seed and pass it explicitly to every dataset. Synchronizing multiple pipelines while also changing their order between training epochs requires explicit epoch/seed coordination; one copied scalar seed cannot provide both behaviors. For corresponding columns or modalities, loading associated data from one primary pipeline through `__url__` and checking `__key__` remains the more robust approach.

The change also makes `WDS_SEED` usable with `detshuffle=True` by converting the environment string to a stable integer base seed, avoiding the existing string-plus-epoch `TypeError`.

## Validation

Regression coverage verifies unseeded reshuffling, explicit and environment seed repeatability, seed precedence, and epoch-aware deterministic shuffle. The related test suite and lint checks pass.