### PR TITLE
Clean up partial cache files after failed downloads

### DIFF
--- a/src/webdataset/cache.py
+++ b/src/webdataset/cache.py
@@ -184,14 +184,21 @@ class LRUCleanup:
 def download(url, dest, chunk_size=1024**2, verbose=False):
     """Download a file from `url` to `dest`."""
     temp = dest + f".temp{os.getpid()}"
-    with gopen.gopen(url) as stream:
-        with open(temp, "wb") as f:
-            while True:
-                data = stream.read(chunk_size)
-                if not data:
-                    break
-                f.write(data)
-    os.rename(temp, dest)
+    try:
+        with gopen.gopen(url) as stream:
+            with open(temp, "wb") as f:
+                while True:
+                    data = stream.read(chunk_size)
+                    if not data:
+                        break
+                    f.write(data)
+        os.rename(temp, dest)
+    except BaseException:
+        try:
+            os.remove(temp)
+        except FileNotFoundError:
+            pass
+        raise
 
 
 class StreamingOpen:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 import pytest
 
+import webdataset.cache as cache
 from webdataset.cache import FileCache, LRUCleanup, StreamingOpen, url_to_cache_name
 
 
@@ -30,6 +31,42 @@ def test_url_to_cache_name():
 def test_url_to_cache_name_non_string_input():
     with pytest.raises(AssertionError):
         url_to_cache_name(123)
+
+
+class FailingStream:
+    def __init__(self, *, fail_on_read=False, fail_on_close=False):
+        self.fail_on_read = fail_on_read
+        self.fail_on_close = fail_on_close
+        self.reads = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.fail_on_close:
+            raise OSError("stream close failed")
+
+    def read(self, size):
+        self.reads += 1
+        if self.fail_on_read and self.reads == 2:
+            raise OSError("stream read failed")
+        return b"partial data" if self.reads == 1 else b""
+
+
+@pytest.mark.parametrize("failure", ["read", "close", "rename"])
+def test_download_removes_temp_file_after_failure(tmp_path, monkeypatch, failure):
+    dest = str(tmp_path / "shard.tar")
+    stream = FailingStream(fail_on_read=failure == "read", fail_on_close=failure == "close")
+    monkeypatch.setattr(cache.gopen, "gopen", lambda url: stream)
+
+    if failure == "rename":
+        monkeypatch.setattr(cache.os, "rename", lambda src, dst: (_ for _ in ()).throw(OSError("rename failed")))
+
+    with pytest.raises(OSError, match=f"{failure} failed"):
+        cache.download("mock://shard", dest)
+
+    assert not os.path.exists(dest)
+    assert not os.path.exists(dest + f".temp{os.getpid()}")
 
 
 class TestStreamingOpen:


### PR DESCRIPTION
### Problem

When a shard download or its final rename fails, `download()` leaves the partially written `.temp<PID>` file in the cache. These files are not cleaned up when caching is unlimited and can accumulate across shards and worker processes.

### Changes

Remove the temporary file on download, stream-close, or rename errors, then re-raise the original exception.

### Tests

Added regression tests for read, stream-close, and rename failures.
